### PR TITLE
fix: ESPHome 2025/11 sensor format

### DIFF
--- a/components/jk_rs485_bms/number/__init__.py
+++ b/components/jk_rs485_bms/number/__init__.py
@@ -33,13 +33,13 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-#from .. import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, jk_bms_ble_ns
+# from .. import CONF_JK_BMS_BLE_ID, JK_BMS_BLE_COMPONENT_SCHEMA, jk_bms_ble_ns
 from .. import CONF_JK_RS485_BMS_ID, JK_RS485_BMS_COMPONENT_SCHEMA, jk_rs485_bms_ns
 
-#DEPENDENCIES = ["jk_bms_ble"]
+# DEPENDENCIES = ["jk_bms_ble"]
 DEPENDENCIES = ["jk_rs485_bms"]
 
-CODEOWNERS = ["@syssi","@txubelaxu"]
+CODEOWNERS = ["@syssi", "@txubelaxu"]
 
 DEFAULT_STEP = 1
 
@@ -62,33 +62,43 @@ CONF_CELL_REQUEST_FLOAT_VOLTAGE = "cell_request_float_voltage"
 CONF_CELL_POWER_OFF_VOLTAGE = "cell_power_off_voltage"
 CONF_CELL_BALANCING_STARTING_VOLTAGE = "cell_balancing_starting_voltage"
 
-CONF_MAX_CHARGING_CURRENT ="max_charging_current"
+CONF_MAX_CHARGING_CURRENT = "max_charging_current"
 CONF_CHARGING_OVERCURRENT_PROTECTION_DELAY = "charging_overcurrent_protection_delay"
-CONF_CHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY = "charging_overcurrent_protection_recovery_delay"
-CONF_MAX_DISCHARGING_CURRENT ="max_discharging_current"
-CONF_DISCHARGING_OVERCURRENT_PROTECTION_DELAY = "discharging_overcurrent_protection_delay"
-CONF_DISCHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY = "discharging_overcurrent_protection_recovery_delay"
-CONF_SHORT_CIRCUIT_PROTECTION_DELAY ="short_circuit_protection_delay"
+CONF_CHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY = (
+    "charging_overcurrent_protection_recovery_delay"
+)
+CONF_MAX_DISCHARGING_CURRENT = "max_discharging_current"
+CONF_DISCHARGING_OVERCURRENT_PROTECTION_DELAY = (
+    "discharging_overcurrent_protection_delay"
+)
+CONF_DISCHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY = (
+    "discharging_overcurrent_protection_recovery_delay"
+)
+CONF_SHORT_CIRCUIT_PROTECTION_DELAY = "short_circuit_protection_delay"
 CONF_SHORT_CIRCUIT_PROTECTION_RECOVERY_DELAY = "short_circuit_protection_recovery_delay"
 CONF_MAX_BALANCING_CURRENT = "max_balancing_current"
 
 CONF_CHARGING_OVERTEMPERATURE_PROTECTION = "charging_overtemperature_protection"
-CONF_CHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY = "charging_overtemperature_protection_recovery"
+CONF_CHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY = (
+    "charging_overtemperature_protection_recovery"
+)
 CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION = "discharging_overtemperature_protection"
-CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY = "discharging_overtemperature_protection_recovery"
+CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY = (
+    "discharging_overtemperature_protection_recovery"
+)
 CONF_CHARGING_LOWTEMPERATURE_PROTECTION = "charging_lowtemperature_protection"
-CONF_CHARGING_LOWTEMPERATURE_PROTECTION_RECOVERY = "charging_lowtemperature_protection_recovery"
+CONF_CHARGING_LOWTEMPERATURE_PROTECTION_RECOVERY = (
+    "charging_lowtemperature_protection_recovery"
+)
 CONF_MOS_OVERTEMPERATURE_PROTECTION = "mos_overtemperature_protection"
 CONF_MOS_OVERTEMPERATURE_PROTECTION_RECOVERY = "mos_overtemperature_protection_recovery"
 
 CONF_CELL_COUNT_SETTINGS = "cell_count_settings"
 CONF_BATTERY_CAPACITY_TOTAL_SETTINGS = "battery_capacity_total_settings"
-CONF_PRECHARGING_TIME_FROM_DISCHARGE = "precharging_time_from_discharge";
+CONF_PRECHARGING_TIME_FROM_DISCHARGE = "precharging_time_from_discharge"
 
 CONF_CELL_REQUEST_CHARGE_VOLTAGE_TIME = "cell_request_charge_voltage_time"
 CONF_CELL_REQUEST_FLOAT_VOLTAGE_TIME = "cell_request_float_voltage_time"
-
-
 
 
 CONF_VOLTAGE_CALIBRATION = "voltage_calibration"
@@ -115,7 +125,7 @@ ICON_ALARM_LOW_VOLUME = "mdi:volume-high"
 ICON_CELL_RESISTANCE = "mdi:omega"
 ICON_BALANCING = "mdi:seesaw"
 ICON_DIRECTION = "mdi:swap-horizontal-bold"
-ICON_CLOCK ="mdi:clock-outline"
+ICON_CLOCK = "mdi:clock-outline"
 
 ICON_HIGH_TEMPERATURE = "mdi:weather-sunny"
 ICON_LOW_TEMPERATURE = "mdi:snowflake"
@@ -158,61 +168,70 @@ UNIT_AMPERE_HOUR = "Ah"
 
 NUMBERS = {
     # JK04, JK02, JK02_32S, factor                          address  3th   L        E^  type (0:uint|1:int)
-    CONF_CELL_SMART_SLEEP_VOLTAGE:                          [0x0000, 0x10,   0x04,  3,  0],      
-    CONF_CELL_UNDERVOLTAGE_PROTECTION:                      [0x0004, 0x10,   0x04,  3,  0],
-    CONF_CELL_UNDERVOLTAGE_PROTECTION_RECOVERY:             [0x0008, 0x10,   0x04,  3,  0],
-    CONF_CELL_OVERVOLTAGE_PROTECTION:                       [0x000C, 0x10,   0x04,  3,  0],
-    CONF_CELL_OVERVOLTAGE_PROTECTION_RECOVERY:              [0x0010, 0x10,   0x04,  3,  0],
-    CONF_CELL_BALANCING_TRIGGER_VOLTAGE:                    [0x0014, 0x10,   0x04,  3,  0],
-    CONF_CELL_SOC100_VOLTAGE:                               [0x0018, 0x10,   0x04,  3,  0],
-    CONF_CELL_SOC0_VOLTAGE:                                 [0x001C, 0x10,   0x04,  3,  0],
-    CONF_CELL_REQUEST_CHARGE_VOLTAGE:                       [0x0020, 0x10,   0x04,  3,  0],
-    CONF_CELL_REQUEST_FLOAT_VOLTAGE:                        [0x0024, 0x10,   0x04,  3,  0],
-    CONF_CELL_POWER_OFF_VOLTAGE:                            [0x0028, 0x10,   0x04,  3,  0],
-    CONF_CELL_BALANCING_STARTING_VOLTAGE:                   [0x0084, 0x10,   0x04,  3,  0],      #02.10.10.84.00.02.04.00.00.0D.70.3D.CC.
+    CONF_CELL_SMART_SLEEP_VOLTAGE: [0x0000, 0x10, 0x04, 3, 0],
+    CONF_CELL_UNDERVOLTAGE_PROTECTION: [0x0004, 0x10, 0x04, 3, 0],
+    CONF_CELL_UNDERVOLTAGE_PROTECTION_RECOVERY: [0x0008, 0x10, 0x04, 3, 0],
+    CONF_CELL_OVERVOLTAGE_PROTECTION: [0x000C, 0x10, 0x04, 3, 0],
+    CONF_CELL_OVERVOLTAGE_PROTECTION_RECOVERY: [0x0010, 0x10, 0x04, 3, 0],
+    CONF_CELL_BALANCING_TRIGGER_VOLTAGE: [0x0014, 0x10, 0x04, 3, 0],
+    CONF_CELL_SOC100_VOLTAGE: [0x0018, 0x10, 0x04, 3, 0],
+    CONF_CELL_SOC0_VOLTAGE: [0x001C, 0x10, 0x04, 3, 0],
+    CONF_CELL_REQUEST_CHARGE_VOLTAGE: [0x0020, 0x10, 0x04, 3, 0],
+    CONF_CELL_REQUEST_FLOAT_VOLTAGE: [0x0024, 0x10, 0x04, 3, 0],
+    CONF_CELL_POWER_OFF_VOLTAGE: [0x0028, 0x10, 0x04, 3, 0],
+    CONF_CELL_BALANCING_STARTING_VOLTAGE: [
+        0x0084,
+        0x10,
+        0x04,
+        3,
+        0,
+    ],  # 02.10.10.84.00.02.04.00.00.0D.70.3D.CC.
     #
-    CONF_MAX_CHARGING_CURRENT:                              [0x002C, 0x10,   0x04,  3,  0],       
-    CONF_CHARGING_OVERCURRENT_PROTECTION_DELAY:             [0x0030, 0x10,   0x04,  0,  0],
-    CONF_CHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY:    [0x0034, 0x10,   0x04,  0,  0],
-    CONF_MAX_DISCHARGING_CURRENT:                           [0x0038, 0x10,   0x04,  3,  0],
-    CONF_DISCHARGING_OVERCURRENT_PROTECTION_DELAY:          [0x003C, 0x10,   0x04,  0,  0],
-    CONF_DISCHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY: [0x0040, 0x10,   0x04,  0,  0],
-    CONF_SHORT_CIRCUIT_PROTECTION_DELAY:                    [0x0080, 0x10,   0x04,  6,  0],
-    CONF_SHORT_CIRCUIT_PROTECTION_RECOVERY_DELAY:           [0x0044, 0x10,   0x04,  0,  0],
-    CONF_MAX_BALANCING_CURRENT:                             [0x0048, 0x10,   0x04,  3,  0],
+    CONF_MAX_CHARGING_CURRENT: [0x002C, 0x10, 0x04, 3, 0],
+    CONF_CHARGING_OVERCURRENT_PROTECTION_DELAY: [0x0030, 0x10, 0x04, 0, 0],
+    CONF_CHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY: [0x0034, 0x10, 0x04, 0, 0],
+    CONF_MAX_DISCHARGING_CURRENT: [0x0038, 0x10, 0x04, 3, 0],
+    CONF_DISCHARGING_OVERCURRENT_PROTECTION_DELAY: [0x003C, 0x10, 0x04, 0, 0],
+    CONF_DISCHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY: [0x0040, 0x10, 0x04, 0, 0],
+    CONF_SHORT_CIRCUIT_PROTECTION_DELAY: [0x0080, 0x10, 0x04, 6, 0],
+    CONF_SHORT_CIRCUIT_PROTECTION_RECOVERY_DELAY: [0x0044, 0x10, 0x04, 0, 0],
+    CONF_MAX_BALANCING_CURRENT: [0x0048, 0x10, 0x04, 3, 0],
     #
-    CONF_CHARGING_OVERTEMPERATURE_PROTECTION:               [0x004C, 0x10,   0x04,  1,  1],
-    CONF_CHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY:      [0x0050, 0x10,   0x04,  1,  1],
-    CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION:            [0x0054, 0x10,   0x04,  1,  1],
-    CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY:   [0x0058, 0x10,   0x04,  1,  1],
-    CONF_CHARGING_LOWTEMPERATURE_PROTECTION:                [0x005C, 0x10,   0x04,  1,  1],
-    CONF_CHARGING_LOWTEMPERATURE_PROTECTION_RECOVERY:       [0x0060, 0x10,   0x04,  1,  1],
-    CONF_MOS_OVERTEMPERATURE_PROTECTION:                    [0x0064, 0x10,   0x04,  1,  1],
-    CONF_MOS_OVERTEMPERATURE_PROTECTION_RECOVERY:           [0x0068, 0x10,   0x04,  1,  1],
+    CONF_CHARGING_OVERTEMPERATURE_PROTECTION: [0x004C, 0x10, 0x04, 1, 1],
+    CONF_CHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY: [0x0050, 0x10, 0x04, 1, 1],
+    CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION: [0x0054, 0x10, 0x04, 1, 1],
+    CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY: [0x0058, 0x10, 0x04, 1, 1],
+    CONF_CHARGING_LOWTEMPERATURE_PROTECTION: [0x005C, 0x10, 0x04, 1, 1],
+    CONF_CHARGING_LOWTEMPERATURE_PROTECTION_RECOVERY: [0x0060, 0x10, 0x04, 1, 1],
+    CONF_MOS_OVERTEMPERATURE_PROTECTION: [0x0064, 0x10, 0x04, 1, 1],
+    CONF_MOS_OVERTEMPERATURE_PROTECTION_RECOVERY: [0x0068, 0x10, 0x04, 1, 1],
     #
-    CONF_CELL_COUNT_SETTINGS:                               [0x006C, 0x10,   0x04,  0,  0],
-    CONF_BATTERY_CAPACITY_TOTAL_SETTINGS:                   [0x007C, 0x10,   0x04,  3,  0],
-    CONF_PRECHARGING_TIME_FROM_DISCHARGE:                   [0x010C, 0x10,   0x04,  3,  0],   ############### TO VERIFY !!!
-
-    CONF_CELL_REQUEST_CHARGE_VOLTAGE_TIME:                  [0x0104, 0x15,   0x02,  1,  0],
-    CONF_CELL_REQUEST_FLOAT_VOLTAGE_TIME:                   [0x0104, 0x15,   0x02,  1,  0],
-
-
-    #0x0104
-    #02.10.15.04.00.01.02.00.01.36.25
-
-    #RCV TIME 
-    #0,1-→ 02.10.15.04.00.01.02.00.01.36.25.                               02.90.03.FC.01 (16)
-    #1,0-→ 02.10.15.04.00.01.02.00.0A.77.E2.                               02.90.03.FC.01 (16)
-
-        #  02.10.15.04.00.01.02.00.00.F7.E5
-        #  02.10.15.04.00.01.02.00.01.36.25
+    CONF_CELL_COUNT_SETTINGS: [0x006C, 0x10, 0x04, 0, 0],
+    CONF_BATTERY_CAPACITY_TOTAL_SETTINGS: [0x007C, 0x10, 0x04, 3, 0],
+    CONF_PRECHARGING_TIME_FROM_DISCHARGE: [
+        0x010C,
+        0x10,
+        0x04,
+        3,
+        0,
+    ],  ############### TO VERIFY !!!
+    CONF_CELL_REQUEST_CHARGE_VOLTAGE_TIME: [0x0104, 0x15, 0x02, 1, 0],
+    CONF_CELL_REQUEST_FLOAT_VOLTAGE_TIME: [0x0104, 0x15, 0x02, 1, 0],
+    # 0x0104
+    # 02.10.15.04.00.01.02.00.01.36.25
+    # RCV TIME
+    # 0,1-→ 02.10.15.04.00.01.02.00.01.36.25.                               02.90.03.FC.01 (16)
+    # 1,0-→ 02.10.15.04.00.01.02.00.0A.77.E2.                               02.90.03.FC.01 (16)
+    #  02.10.15.04.00.01.02.00.00.F7.E5
+    #  02.10.15.04.00.01.02.00.01.36.25
 }
 
-JkRS485BmsNumber = jk_rs485_bms_ns.class_("JkRS485BmsNumber", number.Number, cg.Component)
+JkRS485BmsNumber = jk_rs485_bms_ns.class_(
+    "JkRS485BmsNumber", number.Number, cg.Component
+)
 
 JK_RS485_NUMBER_SCHEMA = (
-    number.number_schema = (
+    number.number_schema(
         JkRS485BmsNumber,
         icon=ICON_EMPTY,
         entity_category=ENTITY_CATEGORY_CONFIG,
@@ -224,7 +243,9 @@ JK_RS485_NUMBER_SCHEMA = (
             cv.Optional(CONF_MODE, default="BOX"): cv.enum(
                 number.NUMBER_MODES, upper=True
             ),
-            cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_EMPTY): cv.string_strict,
+            cv.Optional(
+                CONF_DEVICE_CLASS, default=DEVICE_CLASS_EMPTY
+            ): cv.string_strict,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -234,268 +255,363 @@ CONFIG_SCHEMA = JK_RS485_BMS_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_CELL_SMART_SLEEP_VOLTAGE): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
-                cv.Optional(CONF_STEP, default=0.001): cv.float_,      
+                cv.Optional(CONF_STEP, default=0.001): cv.float_,
                 cv.Optional(
                     CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_CONFIG
-                ): cv.entity_category,   
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                ): cv.entity_category,
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
         ),
         cv.Optional(CONF_CELL_UNDERVOLTAGE_PROTECTION): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
         ),
-        cv.Optional(CONF_CELL_UNDERVOLTAGE_PROTECTION_RECOVERY): JK_RS485_NUMBER_SCHEMA.extend(
+        cv.Optional(
+            CONF_CELL_UNDERVOLTAGE_PROTECTION_RECOVERY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
-        ),        
+        ),
         cv.Optional(CONF_CELL_OVERVOLTAGE_PROTECTION): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
         ),
-        cv.Optional(CONF_CELL_OVERVOLTAGE_PROTECTION_RECOVERY): JK_RS485_NUMBER_SCHEMA.extend(
+        cv.Optional(
+            CONF_CELL_OVERVOLTAGE_PROTECTION_RECOVERY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
-        ),    
+        ),
         cv.Optional(CONF_CELL_BALANCING_TRIGGER_VOLTAGE): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0.001): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=1.0): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
-        ), 
+        ),
         cv.Optional(CONF_CELL_SOC100_VOLTAGE): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
-        ), 
+        ),
         cv.Optional(CONF_CELL_SOC0_VOLTAGE): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
-        ), 
+        ),
         cv.Optional(CONF_CELL_REQUEST_CHARGE_VOLTAGE): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
-        ), 
+        ),
         cv.Optional(CONF_CELL_REQUEST_FLOAT_VOLTAGE): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
         ),
         cv.Optional(CONF_CELL_POWER_OFF_VOLTAGE): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
-        ),  
-        cv.Optional(CONF_CELL_BALANCING_STARTING_VOLTAGE): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_CELL_BALANCING_STARTING_VOLTAGE
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=1.2): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=4.350): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
-                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE):cv.string_strict,                  
+                cv.Optional(
+                    CONF_DEVICE_CLASS, default=DEVICE_CLASS_VOLTAGE
+                ): cv.string_strict,
             }
-        ),         
-
-
-
-
-
+        ),
         cv.Optional(CONF_MAX_CHARGING_CURRENT): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
             }
-        ),  
-        cv.Optional(CONF_CHARGING_OVERCURRENT_PROTECTION_DELAY): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_CHARGING_OVERCURRENT_PROTECTION_DELAY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=3600): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
             }
-        ),  
-        cv.Optional(CONF_CHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_CHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=3600): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
             }
-        ), 
+        ),
         cv.Optional(CONF_MAX_DISCHARGING_CURRENT): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_CURRENT_DC): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_CURRENT_DC): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
             }
-        ),  
-        cv.Optional(CONF_DISCHARGING_OVERCURRENT_PROTECTION_DELAY): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_DISCHARGING_OVERCURRENT_PROTECTION_DELAY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=3600): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
             }
-        ),  
-        cv.Optional(CONF_DISCHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_DISCHARGING_OVERCURRENT_PROTECTION_RECOVERY_DELAY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=3600): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
             }
-        ), 
-
+        ),
         cv.Optional(CONF_SHORT_CIRCUIT_PROTECTION_DELAY): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_MICROSECONDS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_MICROSECONDS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=3600): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
             }
-        ),         
-        cv.Optional(CONF_SHORT_CIRCUIT_PROTECTION_RECOVERY_DELAY): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_SHORT_CIRCUIT_PROTECTION_RECOVERY_DELAY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=3600): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
             }
-        ), 
+        ),
         cv.Optional(CONF_MAX_BALANCING_CURRENT): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_CURRENT_DC): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_CURRENT_DC): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=2): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
             }
-        ),         
-
-
-
-        cv.Optional(CONF_CHARGING_OVERTEMPERATURE_PROTECTION): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_CHARGING_OVERTEMPERATURE_PROTECTION
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,             
-                cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
-                cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
-                cv.Optional(CONF_STEP, default=0.1): cv.float_,
-            }
-        ), 
-
-        cv.Optional(CONF_CHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY): JK_RS485_NUMBER_SCHEMA.extend(
-            {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
                 cv.Optional(CONF_STEP, default=0.1): cv.float_,
             }
         ),
-        cv.Optional(CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION): JK_RS485_NUMBER_SCHEMA.extend(
+        cv.Optional(
+            CONF_CHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
                 cv.Optional(CONF_STEP, default=0.1): cv.float_,
             }
         ),
-        cv.Optional(CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY): JK_RS485_NUMBER_SCHEMA.extend(
+        cv.Optional(
+            CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
                 cv.Optional(CONF_STEP, default=0.1): cv.float_,
             }
         ),
-        cv.Optional(CONF_CHARGING_LOWTEMPERATURE_PROTECTION): JK_RS485_NUMBER_SCHEMA.extend(
+        cv.Optional(
+            CONF_DISCHARGING_OVERTEMPERATURE_PROTECTION_RECOVERY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_LOW_TEMPERATURE): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,
+                cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
+                cv.Optional(CONF_STEP, default=0.1): cv.float_,
+            }
+        ),
+        cv.Optional(
+            CONF_CHARGING_LOWTEMPERATURE_PROTECTION
+        ): JK_RS485_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_LOW_TEMPERATURE): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=-100): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
                 cv.Optional(CONF_STEP, default=0.1): cv.float_,
             }
-        ), 
-
-        cv.Optional(CONF_CHARGING_LOWTEMPERATURE_PROTECTION_RECOVERY): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_CHARGING_LOWTEMPERATURE_PROTECTION_RECOVERY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_LOW_TEMPERATURE): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_LOW_TEMPERATURE): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=-100): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
                 cv.Optional(CONF_STEP, default=0.1): cv.float_,
@@ -503,75 +619,93 @@ CONFIG_SCHEMA = JK_RS485_BMS_COMPONENT_SCHEMA.extend(
         ),
         cv.Optional(CONF_MOS_OVERTEMPERATURE_PROTECTION): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
                 cv.Optional(CONF_STEP, default=0.1): cv.float_,
             }
         ),
-        cv.Optional(CONF_MOS_OVERTEMPERATURE_PROTECTION_RECOVERY): JK_RS485_NUMBER_SCHEMA.extend(
+        cv.Optional(
+            CONF_MOS_OVERTEMPERATURE_PROTECTION_RECOVERY
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_CELSIUS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_HIGH_TEMPERATURE): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=200): cv.float_,
                 cv.Optional(CONF_STEP, default=0.1): cv.float_,
             }
-        ),        
-
+        ),
         cv.Optional(CONF_CELL_COUNT_SETTINGS): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_EMPTY): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_EMPTY
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=3): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=24): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
             }
         ),
-        cv.Optional(CONF_BATTERY_CAPACITY_TOTAL_SETTINGS): JK_RS485_NUMBER_SCHEMA.extend(
+        cv.Optional(
+            CONF_BATTERY_CAPACITY_TOTAL_SETTINGS
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE_HOURS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_BATTERY_CAPACITY_TOTAL_SETTING): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_AMPERE_HOURS
+                ): cv.string_strict,
+                cv.Optional(
+                    CONF_ICON, default=ICON_BATTERY_CAPACITY_TOTAL_SETTING
+                ): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=500): cv.float_,
                 cv.Optional(CONF_STEP, default=0.001): cv.float_,
             }
-        ),       
-        cv.Optional(CONF_PRECHARGING_TIME_FROM_DISCHARGE): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_PRECHARGING_TIME_FROM_DISCHARGE
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECONDS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_CLOCK): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=3600): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
             }
-        ), 
-        cv.Optional(CONF_CELL_REQUEST_CHARGE_VOLTAGE_TIME): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_CELL_REQUEST_CHARGE_VOLTAGE_TIME
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=255): cv.float_,
                 cv.Optional(CONF_STEP, default=0.1): cv.float_,
             }
-        ), 
-        cv.Optional(CONF_CELL_REQUEST_FLOAT_VOLTAGE_TIME): JK_RS485_NUMBER_SCHEMA.extend(
+        ),
+        cv.Optional(
+            CONF_CELL_REQUEST_FLOAT_VOLTAGE_TIME
+        ): JK_RS485_NUMBER_SCHEMA.extend(
             {
-                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS): cv.string_strict,
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,             
+                cv.Optional(
+                    CONF_UNIT_OF_MEASUREMENT, default=UNIT_HOURS
+                ): cv.string_strict,
+                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=255): cv.float_,
                 cv.Optional(CONF_STEP, default=0.1): cv.float_,
             }
-        ),         
-
-
-
-
-
-
-
+        ),
         cv.Optional(CONF_VOLTAGE_CALIBRATION): JK_RS485_NUMBER_SCHEMA.extend(
             {
                 # @FIXME The exact limits are unknown
@@ -596,7 +730,7 @@ CONFIG_SCHEMA = JK_RS485_BMS_COMPONENT_SCHEMA.extend(
 
 
 async def to_code(config):
-    #hub = await cg.get_variable(config[CONF_JK_BMS_BLE_ID])
+    # hub = await cg.get_variable(config[CONF_JK_BMS_BLE_ID])
     hub = await cg.get_variable(config[CONF_JK_RS485_BMS_ID])
     for key, param_config in NUMBERS.items():
         if key in config:
@@ -618,7 +752,4 @@ async def to_code(config):
             cg.add(var.set_factor(param_config[3]))
             cg.add(var.set_type(param_config[4]))
 
-            #[0x0000, 0x10,   0x04,  3,  0],
-
-        
-
+            # [0x0000, 0x10,   0x04,  3,  0],

--- a/components/jk_rs485_bms/number/__init__.py
+++ b/components/jk_rs485_bms/number/__init__.py
@@ -211,19 +211,24 @@ NUMBERS = {
 
 JkRS485BmsNumber = jk_rs485_bms_ns.class_("JkRS485BmsNumber", number.Number, cg.Component)
 
-JK_RS485_NUMBER_SCHEMA = number.NUMBER_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(JkRS485BmsNumber),
-        cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
-        cv.Optional(CONF_STEP, default=0.01): cv.float_,
-        cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_VOLT): cv.string_strict,
-        cv.Optional(CONF_MODE, default="BOX"): cv.enum(number.NUMBER_MODES, upper=True),
-        cv.Optional(
-            CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_CONFIG
-        ): cv.entity_category,
-        cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_EMPTY): cv.string_strict,
-    }
-).extend(cv.COMPONENT_SCHEMA)
+JK_RS485_NUMBER_SCHEMA = (
+    number.number_schema = (
+        JkRS485BmsNumber,
+        icon=ICON_EMPTY,
+        entity_category=ENTITY_CATEGORY_CONFIG,
+        unit_of_measurement=UNIT_VOLT,
+    )
+    .extend(
+        {
+            cv.Optional(CONF_STEP, default=0.01): cv.float_,
+            cv.Optional(CONF_MODE, default="BOX"): cv.enum(
+                number.NUMBER_MODES, upper=True
+            ),
+            cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_EMPTY): cv.string_strict,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 CONFIG_SCHEMA = JK_RS485_BMS_COMPONENT_SCHEMA.extend(
     {

--- a/components/jk_rs485_bms/switch/__init__.py
+++ b/components/jk_rs485_bms/switch/__init__.py
@@ -5,14 +5,26 @@ from esphome.const import CONF_ICON, CONF_ID
 
 from .. import CONF_JK_RS485_BMS_ID, JK_RS485_BMS_COMPONENT_SCHEMA, jk_rs485_bms_ns
 from ..const import (
-    CONF_BALANCING, CONF_PRECHARGING, CONF_CHARGING, CONF_DISCHARGING, CONF_DISPLAY_ALWAYS_ON, CONF_EMERGENCY, CONF_HEATING, CONF_CHARGING_FLOAT_MODE, 
-    CONF_SMART_SLEEP_ON, CONF_DISABLE_PCL_MODULE,CONF_DISABLE_TEMPERATURE_SENSORS, CONF_TIMED_STORED_DATA,
-    CONF_GPS_HEARTBEAT,CONF_PORT_SELECTION,CONF_SPECIAL_CHARGER
+    CONF_BALANCING,
+    CONF_PRECHARGING,
+    CONF_CHARGING,
+    CONF_DISCHARGING,
+    CONF_DISPLAY_ALWAYS_ON,
+    CONF_EMERGENCY,
+    CONF_HEATING,
+    CONF_CHARGING_FLOAT_MODE,
+    CONF_SMART_SLEEP_ON,
+    CONF_DISABLE_PCL_MODULE,
+    CONF_DISABLE_TEMPERATURE_SENSORS,
+    CONF_TIMED_STORED_DATA,
+    CONF_GPS_HEARTBEAT,
+    CONF_PORT_SELECTION,
+    CONF_SPECIAL_CHARGER,
 )
 
 DEPENDENCIES = ["jk_rs485_bms"]
 
-CODEOWNERS = ["@syssi","@txubelaxu"]
+CODEOWNERS = ["@syssi", "@txubelaxu"]
 
 ICON_CHARGING = "mdi:battery-charging-50"
 ICON_DISCHARGING = "mdi:battery-charging-50"
@@ -27,70 +39,77 @@ ICON_CHARGING_FLOAT_MODE = "mdi:battery-charging-80"
 ICON_DISPLAY_ALWAYS_ON = "mdi:television"
 
 SWITCHES = {
-    CONF_CHARGING:                            [0x0070,0x10,0x04],                        #0x1000 -> 0x0078
-    CONF_DISCHARGING:                         [0x0074,0x10,0x04],                        #02.10.10.78.00.02.   04.  00.00.00.00.37.A9
-    CONF_BALANCING:                           [0x0078,0x10,0x04],                       #02.10.10.78.00.02.   04.  00.00.00.01.F6.69.
-
-    CONF_HEATING:                             [0x0014,0x11,0x02],  
-    CONF_DISABLE_TEMPERATURE_SENSORS:         [0x0014,0x11,0x02],     #0x1000 -> 0x0114
-    CONF_GPS_HEARTBEAT:                       [0x0014,0x11,0x02],                   #DISPLAY ALWAYS ON  (0x0114)
-    CONF_PORT_SELECTION:                      [0x0014,0x11,0x02],                  #02.10.11.14.00.01.   02.  02.00.   B1.D5.   OFF
-    CONF_DISPLAY_ALWAYS_ON:                   [0x0014,0x11,0x02],               #02.10.11.14.00.01.   02.  02.10.   B0.19.   ON   0000 0010 0001 0000
-    CONF_SPECIAL_CHARGER:                     [0x0014,0x11,0x02],                  #SMART SLEEP ON
-    CONF_SMART_SLEEP_ON:                      [0x0014,0x11,0x02],                  #02.10.11.14.00.01.   02.  00.10.   B1.79.
-    CONF_DISABLE_PCL_MODULE:                  [0x0014,0x11,0x02],              
-    CONF_TIMED_STORED_DATA:                   [0x0014,0x11,0x02],              
-    CONF_CHARGING_FLOAT_MODE:                 [0x0014,0x11,0x02],             #02.10.11.14.00.01.   02.  02.10.   B0.19.
-
-    CONF_PRECHARGING:                         [0x0000,0x00,0x00],                     #02.10.10.84.00.02.04.00.00.0D.70.3D.CC.
-    CONF_EMERGENCY:                           [0x0000,0x00,0x00],
-  
-    
-    
-    
-    
+    CONF_CHARGING: [0x0070, 0x10, 0x04],  # 0x1000 -> 0x0078
+    CONF_DISCHARGING: [
+        0x0074,
+        0x10,
+        0x04,
+    ],  # 02.10.10.78.00.02.   04.  00.00.00.00.37.A9
+    CONF_BALANCING: [
+        0x0078,
+        0x10,
+        0x04,
+    ],  # 02.10.10.78.00.02.   04.  00.00.00.01.F6.69.
+    CONF_HEATING: [0x0014, 0x11, 0x02],
+    CONF_DISABLE_TEMPERATURE_SENSORS: [0x0014, 0x11, 0x02],  # 0x1000 -> 0x0114
+    CONF_GPS_HEARTBEAT: [0x0014, 0x11, 0x02],  # DISPLAY ALWAYS ON  (0x0114)
+    CONF_PORT_SELECTION: [
+        0x0014,
+        0x11,
+        0x02,
+    ],  # 02.10.11.14.00.01.   02.  02.00.   B1.D5.   OFF
+    CONF_DISPLAY_ALWAYS_ON: [
+        0x0014,
+        0x11,
+        0x02,
+    ],  # 02.10.11.14.00.01.   02.  02.10.   B0.19.   ON   0000 0010 0001 0000
+    CONF_SPECIAL_CHARGER: [0x0014, 0x11, 0x02],  # SMART SLEEP ON
+    CONF_SMART_SLEEP_ON: [
+        0x0014,
+        0x11,
+        0x02,
+    ],  # 02.10.11.14.00.01.   02.  00.10.   B1.79.
+    CONF_DISABLE_PCL_MODULE: [0x0014, 0x11, 0x02],
+    CONF_TIMED_STORED_DATA: [0x0014, 0x11, 0x02],
+    CONF_CHARGING_FLOAT_MODE: [
+        0x0014,
+        0x11,
+        0x02,
+    ],  # 02.10.11.14.00.01.   02.  02.10.   B0.19.
+    CONF_PRECHARGING: [0x0000, 0x00, 0x00],  # 02.10.10.84.00.02.04.00.00.0D.70.3D.CC.
+    CONF_EMERGENCY: [0x0000, 0x00, 0x00],
 }
 
-JkRS485BmsSwitch = jk_rs485_bms_ns.class_("JkRS485BmsSwitch", switch.Switch, cg.Component)
+JkRS485BmsSwitch = jk_rs485_bms_ns.class_(
+    "JkRS485BmsSwitch", switch.Switch, cg.Component
+)
 
 CONFIG_SCHEMA = JK_RS485_BMS_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_PRECHARGING): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_CHARGING): cv.icon,
-            }
+        cv.Optional(CONF_PRECHARGING): switch.switch_schema(
+            JkRS485BmsSwitch,
+            icon=ICON_CHARGING,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_CHARGING): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_CHARGING): cv.icon,
-            }
+        cv.Optional(CONF_CHARGING): switch.switch_schame(
+            JkRS485BmsSwitch,
+            icon=ICON_CHARGING,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_DISCHARGING): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_DISCHARGING): cv.icon,
-            }
+        cv.Optional(CONF_DISCHARGING): switch.switch_schame(
+            JkRS485BmsSwitch,
+            icon=ICON_DISCHARGING,
         ).extend(cv.COMPONENT_SCHEMA),
-         cv.Optional(CONF_BALANCING): switch.SWITCH_SCHEMA.extend(
-             {
-                 cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                 cv.Optional(CONF_ICON, default=ICON_BALANCING): cv.icon,
-             }
-         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_EMERGENCY): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_EMERGENCY): cv.icon,
-            }
-        ).extend(cv.COMPONENT_SCHEMA),  
-        cv.Optional(CONF_HEATING): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_HEATING): cv.icon,
-            }
-        ).extend(cv.COMPONENT_SCHEMA),   
+        cv.Optional(CONF_BALANCING): switch.switch_schame(
+            JkRS485BmsSwitch,
+            icon=ICON_BALANCING,
+        ).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_EMERGENCY): switch.switch_schame(
+            JkRS485BmsSwitch,
+            icon=ICON_EMERGENCY,
+        ).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_HEATING): switch.switch_schame(
+            JkRS485BmsSwitch,
+            icon=ICON_HEATING,
+        ).extend(cv.COMPONENT_SCHEMA),
         cv.Optional(CONF_DISABLE_TEMPERATURE_SENSORS): switch.SWITCH_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
@@ -98,55 +117,55 @@ CONFIG_SCHEMA = JK_RS485_BMS_COMPONENT_SCHEMA.extend(
                     CONF_ICON, default=ICON_DISABLE_TEMPERATURE_SENSORS
                 ): cv.icon,
             }
-        ).extend(cv.COMPONENT_SCHEMA),                    
-         cv.Optional(CONF_DISPLAY_ALWAYS_ON): switch.SWITCH_SCHEMA.extend(
-             {
-                 cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                 cv.Optional(CONF_ICON, default=ICON_DISPLAY_ALWAYS_ON): cv.icon,
-             }
-         ).extend(cv.COMPONENT_SCHEMA),    
+        ).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_DISPLAY_ALWAYS_ON): switch.SWITCH_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
+                cv.Optional(CONF_ICON, default=ICON_DISPLAY_ALWAYS_ON): cv.icon,
+            }
+        ).extend(cv.COMPONENT_SCHEMA),
         cv.Optional(CONF_SMART_SLEEP_ON): switch.SWITCH_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
                 cv.Optional(CONF_ICON, default=ICON_SMART_SLEEP_ON): cv.icon,
             }
-        ).extend(cv.COMPONENT_SCHEMA),    
+        ).extend(cv.COMPONENT_SCHEMA),
         cv.Optional(CONF_TIMED_STORED_DATA): switch.SWITCH_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
                 cv.Optional(CONF_ICON, default=ICON_TIMED_STORED_DATA): cv.icon,
             }
-        ).extend(cv.COMPONENT_SCHEMA),             
+        ).extend(cv.COMPONENT_SCHEMA),
         cv.Optional(CONF_CHARGING_FLOAT_MODE): switch.SWITCH_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
                 cv.Optional(CONF_ICON, default=ICON_CHARGING_FLOAT_MODE): cv.icon,
             }
-        ).extend(cv.COMPONENT_SCHEMA),  
+        ).extend(cv.COMPONENT_SCHEMA),
         cv.Optional(CONF_DISABLE_PCL_MODULE): switch.SWITCH_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
                 cv.Optional(CONF_ICON, default=ICON_DISABLE_PCL_MODULE): cv.icon,
             }
-        ).extend(cv.COMPONENT_SCHEMA),    
+        ).extend(cv.COMPONENT_SCHEMA),
         cv.Optional(CONF_GPS_HEARTBEAT): switch.SWITCH_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
                 cv.Optional(CONF_ICON, default=ICON_DISABLE_PCL_MODULE): cv.icon,
             }
-        ).extend(cv.COMPONENT_SCHEMA),  
+        ).extend(cv.COMPONENT_SCHEMA),
         cv.Optional(CONF_PORT_SELECTION): switch.SWITCH_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
                 cv.Optional(CONF_ICON, default=ICON_DISABLE_PCL_MODULE): cv.icon,
             }
-        ).extend(cv.COMPONENT_SCHEMA), 
+        ).extend(cv.COMPONENT_SCHEMA),
         cv.Optional(CONF_SPECIAL_CHARGER): switch.SWITCH_SCHEMA.extend(
             {
                 cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
                 cv.Optional(CONF_ICON, default=ICON_DISABLE_PCL_MODULE): cv.icon,
             }
-        ).extend(cv.COMPONENT_SCHEMA),         
+        ).extend(cv.COMPONENT_SCHEMA),
     }
 )
 

--- a/components/jk_rs485_bms/switch/__init__.py
+++ b/components/jk_rs485_bms/switch/__init__.py
@@ -90,23 +90,23 @@ CONFIG_SCHEMA = JK_RS485_BMS_COMPONENT_SCHEMA.extend(
             JkRS485BmsSwitch,
             icon=ICON_CHARGING,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_CHARGING): switch.switch_schame(
+        cv.Optional(CONF_CHARGING): switch.switch_schema(
             JkRS485BmsSwitch,
             icon=ICON_CHARGING,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_DISCHARGING): switch.switch_schame(
+        cv.Optional(CONF_DISCHARGING): switch.switch_schema(
             JkRS485BmsSwitch,
             icon=ICON_DISCHARGING,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_BALANCING): switch.switch_schame(
+        cv.Optional(CONF_BALANCING): switch.switch_schema(
             JkRS485BmsSwitch,
             icon=ICON_BALANCING,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_EMERGENCY): switch.switch_schame(
+        cv.Optional(CONF_EMERGENCY): switch.switch_schema(
             JkRS485BmsSwitch,
             icon=ICON_EMERGENCY,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_HEATING): switch.switch_schame(
+        cv.Optional(CONF_HEATING): switch.switch_schema(
             JkRS485BmsSwitch,
             icon=ICON_HEATING,
         ).extend(cv.COMPONENT_SCHEMA),

--- a/components/jk_rs485_bms/switch/__init__.py
+++ b/components/jk_rs485_bms/switch/__init__.py
@@ -110,61 +110,41 @@ CONFIG_SCHEMA = JK_RS485_BMS_COMPONENT_SCHEMA.extend(
             JkRS485BmsSwitch,
             icon=ICON_HEATING,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_DISABLE_TEMPERATURE_SENSORS): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(
-                    CONF_ICON, default=ICON_DISABLE_TEMPERATURE_SENSORS
-                ): cv.icon,
-            }
+        cv.Optional(CONF_DISABLE_TEMPERATURE_SENSORS): switch.switch_schema(
+            JkRS485BmsSwitch,
+            icon=ICON_DISABLE_TEMPERATURE_SENSORS,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_DISPLAY_ALWAYS_ON): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_DISPLAY_ALWAYS_ON): cv.icon,
-            }
+        cv.Optional(CONF_DISPLAY_ALWAYS_ON): switch.switch_schema(
+            JkRS485BmsSwitch,
+            icon=ICON_DISPLAY_ALWAYS_ON,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_SMART_SLEEP_ON): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_SMART_SLEEP_ON): cv.icon,
-            }
+        cv.Optional(CONF_SMART_SLEEP_ON): switch.switch_schema(
+            JkRS485BmsSwitch,
+            icon=ICON_SMART_SLEEP_ON,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_TIMED_STORED_DATA): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_TIMED_STORED_DATA): cv.icon,
-            }
+        cv.Optional(CONF_TIMED_STORED_DATA): switch.switch_schema(
+            JkRS485BmsSwitch,
+            icon=ICON_TIMED_STORED_DATA,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_CHARGING_FLOAT_MODE): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_CHARGING_FLOAT_MODE): cv.icon,
-            }
+        cv.Optional(CONF_CHARGING_FLOAT_MODE): switch.switch_schema(
+            JkRS485BmsSwitch,
+            icon=ICON_CHARGING_FLOAT_MODE,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_DISABLE_PCL_MODULE): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_DISABLE_PCL_MODULE): cv.icon,
-            }
+        cv.Optional(CONF_DISABLE_PCL_MODULE): switch.switch_schema(
+            JkRS485BmsSwitch,
+            icon=ICON_DISABLE_PCL_MODULE,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_GPS_HEARTBEAT): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_DISABLE_PCL_MODULE): cv.icon,
-            }
+        cv.Optional(CONF_GPS_HEARTBEAT): switch.switch_schema(
+            JkRS485BmsSwitch,
+            icon=ICON_DISABLE_PCL_MODULE,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_PORT_SELECTION): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_DISABLE_PCL_MODULE): cv.icon,
-            }
+        cv.Optional(CONF_PORT_SELECTION): switch.switch_schema(
+            JkRS485BmsSwitch,
+            icon=ICON_DISABLE_PCL_MODULE,
         ).extend(cv.COMPONENT_SCHEMA),
-        cv.Optional(CONF_SPECIAL_CHARGER): switch.SWITCH_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(JkRS485BmsSwitch),
-                cv.Optional(CONF_ICON, default=ICON_DISABLE_PCL_MODULE): cv.icon,
-            }
+        cv.Optional(CONF_SPECIAL_CHARGER): switch.switch_schema(
+            JkRS485BmsSwitch,
+            icon=ICON_DISABLE_PCL_MODULE,
         ).extend(cv.COMPONENT_SCHEMA),
     }
 )

--- a/components/jk_rs485_bms/text_sensor.py
+++ b/components/jk_rs485_bms/text_sensor.py
@@ -7,7 +7,7 @@ from . import CONF_JK_RS485_BMS_ID, JK_RS485_BMS_COMPONENT_SCHEMA
 
 DEPENDENCIES = ["jk_rs485_bms"]
 
-CODEOWNERS = ["@syssi","@txubelaxu"]
+CODEOWNERS = ["@syssi", "@txubelaxu"]
 
 CONF_BATTERY_TYPE = "battery_type"
 CONF_ERRORS = "errors"
@@ -19,12 +19,12 @@ CONF_TOTAL_RUNTIME_FORMATTED = "total_runtime_formatted"
 CONF_NETWORK_NODES_AVAILABLE = "network_nodes_available"
 
 CONF_INFO_VENDORID = "info_vendorid"
-CONF_INFO_HARDWARE_VERSION = "info_hardware_version";
-CONF_INFO_SOFTWARE_VERSION = "info_software_version";
-CONF_INFO_DEVICE_NAME = "info_device_name";
-CONF_INFO_DEVICE_PASSWORD = "info_device_password";
-CONF_INFO_DEVICE_SERIAL_NUMBER = "info_device_serial_number";
-CONF_INFO_DEVICE_SETUP_PASSCODE = "info_device_setup_passcode";
+CONF_INFO_HARDWARE_VERSION = "info_hardware_version"
+CONF_INFO_SOFTWARE_VERSION = "info_software_version"
+CONF_INFO_DEVICE_NAME = "info_device_name"
+CONF_INFO_DEVICE_PASSWORD = "info_device_password"
+CONF_INFO_DEVICE_SERIAL_NUMBER = "info_device_serial_number"
+CONF_INFO_DEVICE_SETUP_PASSCODE = "info_device_setup_passcode"
 
 ICON_BATTERY_TYPE = "mdi:car-battery"
 ICON_ERRORS = "mdi:alert-circle-outline"
@@ -44,130 +44,65 @@ TEXT_SENSORS = [
     CONF_MANUFACTURER,
     CONF_TOTAL_RUNTIME_FORMATTED,
     CONF_NETWORK_NODES_AVAILABLE,
-
     CONF_INFO_VENDORID,
     CONF_INFO_HARDWARE_VERSION,
     CONF_INFO_SOFTWARE_VERSION,
     CONF_INFO_DEVICE_NAME,
     CONF_INFO_DEVICE_PASSWORD,
-    CONF_INFO_DEVICE_SERIAL_NUMBER,   
-    CONF_INFO_DEVICE_SETUP_PASSCODE, 
+    CONF_INFO_DEVICE_SERIAL_NUMBER,
+    CONF_INFO_DEVICE_SETUP_PASSCODE,
 ]
 
 CONFIG_SCHEMA = JK_RS485_BMS_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_OPERATION_STATUS): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_OPERATION_MODE): cv.icon,
-            }
+        cv.Optional(CONF_OPERATION_STATUS): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_OPERATION_MODE
         ),
-        cv.Optional(CONF_ERRORS): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_ERRORS): cv.icon,
-            }
+        cv.Optional(CONF_ERRORS): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_ERRORS
         ),
-        cv.Optional(CONF_BATTERY_TYPE): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_BATTERY_TYPE): cv.icon,
-            }
+        cv.Optional(CONF_BATTERY_TYPE): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_BATTERY_TYPE
         ),
-        cv.Optional(CONF_PASSWORD): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_PASSWORD): cv.icon,
-            }
+        cv.Optional(CONF_PASSWORD): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_PASSWORD
         ),
-        cv.Optional(CONF_DEVICE_TYPE): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
-            }
+        cv.Optional(CONF_DEVICE_TYPE): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_EMPTY
         ),
-        cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
-            }
+        cv.Optional(CONF_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_EMPTY
         ),
-        cv.Optional(CONF_MANUFACTURER): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_EMPTY): cv.icon,
-            }
+        cv.Optional(CONF_MANUFACTURER): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_EMPTY
         ),
-        cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_TIMELAPSE): cv.icon,
-            }
+        cv.Optional(CONF_TOTAL_RUNTIME_FORMATTED): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_TIMELAPSE
         ),
-        cv.Optional(CONF_NETWORK_NODES_AVAILABLE): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_NETWORK): cv.icon,
-            }
-        ),    
-        cv.Optional(
-            CONF_INFO_VENDORID
-        ): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_INFORMATION): cv.icon,
-            }
+        cv.Optional(CONF_NETWORK_NODES_AVAILABLE): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_NETWORK
         ),
-        cv.Optional(
-            CONF_INFO_HARDWARE_VERSION
-        ): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_INFORMATION): cv.icon,
-            }
+        cv.Optional(CONF_INFO_VENDORID): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_INFORMATION
         ),
-        cv.Optional(
-            CONF_INFO_SOFTWARE_VERSION
-        ): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_INFORMATION): cv.icon,
-            }
+        cv.Optional(CONF_INFO_HARDWARE_VERSION): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_INFORMATION
         ),
-        cv.Optional(
-            CONF_INFO_DEVICE_NAME
-        ): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_INFORMATION): cv.icon,
-            }
+        cv.Optional(CONF_INFO_SOFTWARE_VERSION): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_INFORMATION
         ),
-        cv.Optional(
-            CONF_INFO_DEVICE_PASSWORD
-        ): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_INFORMATION): cv.icon,
-            }
-        ),   
-        cv.Optional(
-            CONF_INFO_DEVICE_SERIAL_NUMBER
-        ): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_INFORMATION): cv.icon,
-            }
-        ),                    
-        cv.Optional(
-            CONF_INFO_DEVICE_SETUP_PASSCODE
-        ): text_sensor.TEXT_SENSOR_SCHEMA.extend(
-            {
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(CONF_ICON, default=ICON_INFORMATION): cv.icon,
-            }
-        ),   
-
-        
+        cv.Optional(CONF_INFO_DEVICE_NAME): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_INFORMATION
+        ),
+        cv.Optional(CONF_INFO_DEVICE_PASSWORD): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_INFORMATION
+        ),
+        cv.Optional(CONF_INFO_DEVICE_SERIAL_NUMBER): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_INFORMATION
+        ),
+        cv.Optional(CONF_INFO_DEVICE_SETUP_PASSCODE): text_sensor.text_sensor_schema(
+            text_sensor.TextSensor, icon=ICON_INFORMATION
+        ),
     }
 )
 


### PR DESCRIPTION
Fixes the deprecation of number, switch and text format such as text_sensor.TEXT_SENSOR_SCHEMA that it is no long supported in next version of ESP Home.