### PR TITLE
Merge development_20260401 into main for v1.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tests/
 secrets.yaml
 components/jk_rs485_sniffer/old_snif.cpp
 **/*.sh
+logs/esphome-run.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The newest entries appear first.
+
+## 2026-05-22
+
+### Fixed
+
+- Preserved the latest `network_nodes_available` value while keeping text sensor throttling enabled.
+- Deferred publication of pending `network_nodes_available` updates until the next allowed publish window.
+
+## 2026-05-21
+
+### Added
+
+- Added `CHANGELOG.md` and linked it from `README.md`.
+
+### Changed
+
+- Moved publish interval settings to `jk_rs485_sniffer` configuration.
+- Added YAML options for `sensor_publish_interval`, `number_publish_interval`, and `text_publish_interval`.
+- Kept default publish intervals at `10s` when the new options are not provided.
+
+### Fixed
+
+- Removed invalid `ESP_LOG_LEVEL` checks from the sniffer hot path.
+- Disabled expensive buffer dumps in the sniffer hot path to reduce loop blocking.
+- Improved Home Assistant API responsiveness by reducing sniffer hot-path overhead.
+
+## 2026-05-20
+
+### Added
+
+- Configurable publish intervals for sensors, numbers, and text sensors from `jk_rs485_sniffer`, with `10s` defaults.
+
+### Changed
+
+- Delayed non-binary state publications to reduce API load and Home Assistant reconnection issues.
+- Reduced UART broadcast delays in the sniffer to improve timing and responsiveness.
+- Kept binary sensors and alarm publications immediate while throttling sensors, numbers, and text sensors.
+
+### Fixed
+
+- Made `cell_count_settings` optional for online detection logic.
+- Added crash guards for short frames and invalid cell counts during `decode_jk02_cell_info_()`.
+- Improved stability around API disconnects and high publish rates.
+
+## 2026-04-07
+
+### Fixed
+
+- Allowed RS485 address `0x00` in `jk_rs485_bms` configuration validation.
+- Cleaned offset handling in JK02 frame decoding.
+- Removed unsafe `arr[1]` split handling from cell info decoding.
+- Removed dead `JkRS485Bms_init()` code and replaced invalid null checks with real parent guards.
+- Added null guards for optional switches, numbers, and online tracking dependencies.
+- Hardened the sniffer RX buffer parser against invalid pointer reuse after buffer erases.
+
+## 2025-11-03
+
+### Changed
+
+- Merged formatting compatibility updates for ESPHome 2025.11.
+
+## 2025-11-02
+
+### Changed
+
+- Updated text sensor definitions.
+- Updated additional schema definitions.
+
+## 2025-11-01
+
+### Changed
+
+- Partially rewrote `switch` schema definitions.
+- Updated `number` schema format.
+
+### Fixed
+
+- Fixed minor typos.
+
+## 2025-08-25
+
+### Changed
+
+- Updated release version metadata.
+- Merged development updates for the `v19_20250817` line.
+
+## 2025-08-20
+
+### Changed
+
+- Improved traces and debugging output.
+
+## 2025-08-19
+
+### Changed
+
+- Extended `decode_device_info_()` handling.
+
+## 2025-08-18
+
+### Changed
+
+- Reworked frame handling and debugging during protocol analysis.
+- Added temporary print/debug helpers used while decoding all frame types.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,107 @@
+# Project Memory
+
+## Purpose
+
+This repository provides custom ESPHome components for monitoring JK-BMS PB 15.x devices over RS-485, with support for multi-node RS-485 networks and Home Assistant integration.
+
+The implementation is centered on a shared RS-485 sniffer/hub and one or more per-BMS device instances bound to RS-485 addresses.
+
+## Current Documentation Baseline
+
+- `README.md` is a high-level entry point and links to the external manual/tutorial repository.
+- `README.md` still highlights historical release notes up to `V1.6`, so it is not the best source for the latest implementation state.
+- `CHANGELOG.md` is the most reliable in-repo source for recent behavior changes. The latest entry at the time of this memory is `2026-05-22`.
+
+## Repository Shape
+
+- `components/jk_rs485_sniffer/`
+  - Shared UART/RS-485 component.
+  - Owns protocol selection, RX timeout, optional talk pin, and publish throttling intervals.
+- `components/jk_rs485_bms/`
+  - Per-device component registered against one sniffer instance.
+  - Owns decoding, entity publication, online-state tracking, and BMS-address-specific behavior.
+  - Includes Python schema glue plus C++ runtime logic.
+- `components/jk_rs485_bms/number/`
+  - Number entities and write-back controls.
+- `components/jk_rs485_bms/switch/`
+  - Switch entities and write-back controls.
+- Top-level YAML files
+  - Local configuration, development, and protocol-analysis fixtures.
+  - Several `faker_*.yaml` and `juanmi_*.yml` files appear to be capture or simulation assets used during protocol work.
+- `logs/`
+  - Local diagnostic output storage.
+
+## Effective Architecture
+
+### `jk_rs485_sniffer`
+
+Main configuration responsibilities inferred from `components/jk_rs485_sniffer/__init__.py`:
+
+- Depends on `uart`.
+- Supports multiple instances (`MULTI_CONF = True`).
+- Requires `protocol_version`.
+- Accepts optional:
+  - `master_fw_version`
+  - `talk_pin`
+  - `rx_timeout`
+  - `sensor_publish_interval`
+  - `number_publish_interval`
+  - `text_publish_interval`
+- Default publish intervals are `10s`.
+
+This component acts as the transport-level coordinator and rate-limiting source for child BMS devices.
+
+### `jk_rs485_bms`
+
+Main configuration responsibilities inferred from `components/jk_rs485_bms/__init__.py`:
+
+- Depends on a parent `jk_rs485_sniffer`.
+- Supports multiple instances (`MULTI_CONF = True`).
+- Requires `rs485_address` in the range `0..15`.
+- Uses a polling interval of `5s`.
+
+This component represents a logical BMS node attached to the shared sniffer and publishes sensors, binary sensors, text sensors, numbers, and switches.
+
+## Important Recent Behavior
+
+Based on `CHANGELOG.md`, the current implementation priorities are stability and API responsiveness rather than raw publish immediacy.
+
+Key recent themes:
+
+- Publish throttling was introduced and then moved to `jk_rs485_sniffer` configuration.
+- Non-binary publications are intentionally delayed to reduce Home Assistant/API pressure.
+- Binary sensors and alarm publications remain immediate.
+- `network_nodes_available` required a follow-up fix so its latest value is preserved while text sensor throttling is active.
+- Decoder hardening was added for short frames, invalid cell counts, optional entities, parent guards, and buffer/parser safety.
+- `cell_count_settings` was made optional for online detection.
+- Address `0x00` is now allowed by validation.
+
+## Observed Runtime Concerns
+
+The changelog and code search point to a few sensitive areas that deserve extra care in future work:
+
+- RS-485 timing and UART loop blocking.
+- Home Assistant API disconnects caused by aggressive publishing.
+- Online-state lifecycle, which depends on frame arrival and valid cell metadata.
+- Text/sensor/number throttling interactions with state freshness.
+- Frame parsing robustness when protocol captures are incomplete or malformed.
+
+## Maintenance Notes
+
+- The project mixes ESPHome Python schema definitions with C++ runtime code. Changes usually need review in both layers.
+- The repository contains active development fixtures and debug-oriented YAML assets; avoid treating them as dead files without confirming their workflow role.
+- `setup.cfg` shows flake8 docstring rules intentionally disabled, but the repository-level working preference should still be to add useful documentation when touching important logic.
+- There was no dedicated project memory file before this one.
+
+## Suggested Source Priority For Future Sessions
+
+When reconstructing project intent, prefer this order:
+
+1. `CHANGELOG.md` for latest behavior changes.
+2. `components/jk_rs485_sniffer/__init__.py` and `components/jk_rs485_bms/__init__.py` for effective config surface.
+3. C++ runtime files under `components/` for actual behavior and edge-case handling.
+4. `README.md` for project overview and external documentation entry points.
+
+## Snapshot Date
+
+This memory was created on `2026-05-31` from the current repository state.

--- a/README.md
+++ b/README.md
@@ -16,28 +16,43 @@ Everything you need is here!
 
 **[Click here](https://github.com/rabbit3dcustom/esphome-jk-bms-documentation/tree/main/esphome-jk-bms-component/README.md) for more info.**
 
+## Changes
+
+See [CHANGELOG.md](./CHANGELOG.md).
+
 ## Release versions
 
+- V1.6: https://github.com/rabbit3dcustom/esphome-jk-bms/releases/tag/v1.6
+  - Home assisant losts communication all the time.
+  - ESPHome unable to disconnect API.
+  - ESP32 ends failing.
+  - Added publishing intervals to avoid time-out and reconnections.
+  - Tested on JK-PB v19 fw:19.03;fw:19.16
+
+- V1.5: https://github.com/rabbit3dcustom/esphome-jk-bms/releases/tag/v1.5
+  - SCHEMA DEPRECATED improvement
+  - Tested on JK-PB v19 fw:19.03;fw:19.16
+
 - V1.4: https://github.com/rabbit3dcustom/esphome-jk-bms/releases/tag/v1.4
-    - Refactoring code.
-    - Tested on JK-PB v19 fw:19.03
+  - Refactoring code.
+  - Tested on JK-PB v19 fw:19.03
 
 - V1.3: https://github.com/rabbit3dcustom/esphome-jk-bms/releases/tag/v1.3
-    - Bug: Alarms are again active.
+  - Bug: Alarms are again active.
 
 - V1.2: https://github.com/rabbit3dcustom/esphome-jk-bms/releases/tag/v1.2
-    - Improve logs: VERY_VERBOSE and INFO
-    - Better frame detection
-    - Fast response to esphome
+  - Improve logs: VERY_VERBOSE and INFO
+  - Better frame detection
+  - Fast response to esphome
 
-- V1.0: https://github.com/rabbit3dcustom/esphome-jk-bms/releases/tag/v.1.0 
-    - Clean non mandatory files.
-    - Avoid downloading the home assistant dashboards into the ESP32 compilation
-    - Avoid downloading all the docs related to protocols
+- V1.0: https://github.com/rabbit3dcustom/esphome-jk-bms/releases/tag/v.1.0
+  - Clean non mandatory files.
+  - Avoid downloading the home assistant dashboards into the ESP32 compilation
+  - Avoid downloading all the docs related to protocols
 
 ## Thanks to
 
-Txubelatxu: https://github.com/txubelaxu/esphome-jk-bms 
+Txubelatxu: https://github.com/txubelaxu/esphome-jk-bms
 
 syssi: https://github.com/syssi/esphome-jk-bms
 
@@ -47,13 +62,13 @@ If you want to tip me for this work, you can now buy me a coffee
 
 [!["Buy Me A Coffee"](https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg)](https://coff.ee/rabbit3dcustom)
 
-
 <details>
 
 <summary>Other related information</summary>
 
 ## Other related
-**NEW:** monitor your new JK-PBx BMSs via internal RS485 network using 1 only ESP.  Home Assistant dashboards inside as well.
+
+**NEW:** monitor your new JK-PBx BMSs via internal RS485 network using 1 only ESP. Home Assistant dashboards inside as well.
 
 **Last Change:** Added RCV Time and RFV Time as Read & Write
 

--- a/components/jk_rs485_bms/__init__.py
+++ b/components/jk_rs485_bms/__init__.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(JkRS485Bms),
-            cv.Required(CONF_RS485_ADDRESS): cv.int_,
+            cv.Required(CONF_RS485_ADDRESS): cv.int_range(min=1, max=15),
         }
     )
     .extend(cv.polling_component_schema("5s"))

--- a/components/jk_rs485_bms/__init__.py
+++ b/components/jk_rs485_bms/__init__.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(JkRS485Bms),
-            cv.Required(CONF_RS485_ADDRESS): cv.int_range(min=1, max=15),
+            cv.Required(CONF_RS485_ADDRESS): cv.int_range(min=0, max=15),
         }
     )
     .extend(cv.polling_component_schema("5s"))

--- a/components/jk_rs485_bms/jk_rs485_bms.cpp
+++ b/components/jk_rs485_bms/jk_rs485_bms.cpp
@@ -217,6 +217,9 @@ void JkRS485Bms::set_cell_request_float_voltage_time_number(JkRS485BmsNumber *ce
 }
 
 static const char *const TAG = "jk_rs485_bms";
+static const uint32_t SENSOR_PUBLISH_INTERVAL_MS = 10000;
+static const uint32_t NUMBER_PUBLISH_INTERVAL_MS = 10000;
+static const uint32_t TEXT_PUBLISH_INTERVAL_MS = 10000;
 
 static const uint8_t MAX_NO_RESPONSE_COUNT = 10;
 
@@ -1773,6 +1776,22 @@ void JkRS485Bms::publish_state_(binary_sensor::BinarySensor *binary_sensor, cons
   binary_sensor->publish_state(state);
 }
 
+bool JkRS485Bms::should_publish_now_(uintptr_t key, uint32_t interval_ms, bool force_publish) {
+  if (force_publish) {
+    this->last_publish_millis_[key] = millis();
+    return true;
+  }
+
+  const uint32_t now = millis();
+  auto it = this->last_publish_millis_.find(key);
+  if (it == this->last_publish_millis_.end() || now - it->second >= interval_ms) {
+    this->last_publish_millis_[key] = now;
+    return true;
+  }
+
+  return false;
+}
+
 // void JkRS485Bms::publish_state_(sensor::Sensor *sensor, float value) {
 //   if (sensor == nullptr)
 //     return;
@@ -1794,6 +1813,10 @@ void JkRS485Bms::publish_state_(sensor::Sensor *sensor, float value) {
     return;
   }
   ESP_LOGVV(TAG, "Debug point 102 (--> %f)", value);
+  const bool force_publish = std::isnan(value);
+  if (!this->should_publish_now_(reinterpret_cast<uintptr_t>(sensor), SENSOR_PUBLISH_INTERVAL_MS, force_publish)) {
+    return;
+  }
   sensor->publish_state(value);
 
   // ESP_LOGD(TAG, "  --------------------------------------- TRYING     0x%02X ",
@@ -1831,6 +1854,10 @@ void JkRS485Bms::publish_state_(JkRS485BmsNumber *number, float value) {
   const size_t free_heap = heap_caps_get_largest_free_block(MALLOC_CAP_8BIT);
 
   if (reinterpret_cast<uintptr_t>(number) > 0x3f000000) {
+    const bool force_publish = std::isnan(value);
+    if (!this->should_publish_now_(reinterpret_cast<uintptr_t>(number), NUMBER_PUBLISH_INTERVAL_MS, force_publish)) {
+      return;
+    }
     ESP_LOGV(TAG, "       ]* Publishing state %f for object with address %p [%f] %s", value, (void *) number,
              ((float) free_heap / 1024), number->get_name().c_str());
     number->publish_state(value);
@@ -1853,6 +1880,10 @@ void JkRS485Bms::publish_state_(text_sensor::TextSensor *text_sensor, const std:
     return;
   }
 
+  const bool force_publish = state == "Offline";
+  if (!this->should_publish_now_(reinterpret_cast<uintptr_t>(text_sensor), TEXT_PUBLISH_INTERVAL_MS, force_publish)) {
+    return;
+  }
   text_sensor->publish_state(state);
 }
 

--- a/components/jk_rs485_bms/jk_rs485_bms.cpp
+++ b/components/jk_rs485_bms/jk_rs485_bms.cpp
@@ -735,17 +735,6 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   this->publish_state_(this->cell_resistance_min_cell_number_sensor_, (float) cell_resistance_min_cell_number + 1);
   ESP_LOGVV(TAG, "Debug point 002");
 
-  if (this->arr[1] == 0) {
-    this->arr[1] = 1;
-  } else {
-    if (this->arr[1] == 1) {
-      this->arr[1] = 2;
-    } else {
-      this->arr[1] = 0;
-    }
-  }
-  ESP_LOGD(TAG, " array 1 = %d", arr[1]);
-
   // ESP_LOGV(TAG, "Cell MAX voltage:    %f", cell_voltage_max);
   // ESP_LOGV(TAG, "Cell MAX voltage:    %f", cell_voltage_min);
 
@@ -760,10 +749,8 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   // ESP_LOGV(TAG, "Enabled cells bitmask: 0x%02X 0x%02X 0x%02X 0x%02X", data[54 + offset], data[55 + offset],data[56
   // + offset], data[57 + offset]);
 
-  if (this->arr[1] == 0) {
-    ESP_LOGD(TAG, " ===============================================================================================");
-    ESP_LOGD(TAG, " if (this->arr[1] == 0)");
-    ESP_LOGD(TAG, " if (this->arr[1] == 0) - offset: %d) ", offset);
+  ESP_LOGD(TAG, " ===============================================================================================");
+  ESP_LOGD(TAG, " block A - offset: %d) ", offset);
 
     // 58    2   0x00 0x0D              cell average voltage  0.001        V
     this->publish_state_(this->cell_average_voltage_sensor_,
@@ -889,12 +876,8 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
           int16_to_float(&data[134 + offset]) * 0.1f);  //  (float) ((int16_t) jk_get_16bit(134 + offset)) * 0.1f);
     }
 
-  } else {
-    if (this->arr[1] == 1) {
       ESP_LOGD(TAG, " ===============================================================================================");
-
-      ESP_LOGD(TAG, " if (this->arr[1] == 1)");
-      ESP_LOGD(TAG, " if (this->arr[1] == 1) - offset: %d) ", offset);
+      ESP_LOGD(TAG, " block B - offset: %d) ", offset);
 
       offset = offset * 2;
 
@@ -992,13 +975,12 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
       this->publish_state_(this->battery_soh_valuation_sensor_,
                            temp_param_value);  //  (float) jk_get_32bit(158 + offset));
 
-    } else {
       ESP_LOGD(TAG, " ===============================================================================================");
-      ESP_LOGD(TAG, " if (this->arr[1] == 2)");
+      ESP_LOGD(TAG, " block C");
 
       offset = offset * 2;  // Copy the offset from the previous conditional.
 
-      ESP_LOGD(TAG, " if (this->arr[1] == 2) - offset: %d) ", offset);
+      ESP_LOGD(TAG, " block C - offset: %d) ", offset);
 
       // 159  [185=159+26]  1   0x00                   Precharge
       // ESP_LOGV(TAG, "Precharge: 0x%02X (always 0x00?)", data[159 + offset]);
@@ -1156,9 +1138,6 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
         this->publish_state_(this->battery_total_alarms_count_sensor_, (float) this->battery_total_alarms_count_);
         this->publish_state_(this->battery_total_alarms_active_sensor_, (float) this->battery_total_alarms_active_);
       }
-    } /* else (this->arr[1] == */
-  } /* if (this->arr[1] == */
-
   this->status_notification_received_ = true;
   this->trigger_bms2sniffer_event("WORKING ! #####", 02);
 }

--- a/components/jk_rs485_bms/jk_rs485_bms.cpp
+++ b/components/jk_rs485_bms/jk_rs485_bms.cpp
@@ -53,213 +53,6 @@ float int16_to_float(const uint8_t *byteArray) {
 namespace esphome {
 namespace jk_rs485_bms {
 
-void JkRS485Bms::JkRS485Bms_init(void) {
-  this->precharging_switch_ = new JkRS485BmsSwitch(false);
-  this->charging_switch_ = new JkRS485BmsSwitch(false);
-  this->discharging_switch_ = new JkRS485BmsSwitch(false);
-  this->balancer_switch_ = new JkRS485BmsSwitch(false);
-  this->emergency_switch_ = new JkRS485BmsSwitch(false);
-  this->heating_switch_ = new JkRS485BmsSwitch(false);
-  this->charging_float_mode_switch_ = new JkRS485BmsSwitch(false);
-  this->disable_temperature_sensors_switch_ = new JkRS485BmsSwitch(false);
-  this->display_always_on_switch_ = new JkRS485BmsSwitch(false);
-  this->smart_sleep_on_switch_ = new JkRS485BmsSwitch(false);
-  this->timed_stored_data_switch_ = new JkRS485BmsSwitch(false);
-  this->disable_pcl_module_switch_ = new JkRS485BmsSwitch(false);
-  this->gps_heartbeat_switch_ = new JkRS485BmsSwitch(false);
-  this->port_selection_switch_ = new JkRS485BmsSwitch(false);
-  this->special_charger_switch_ = new JkRS485BmsSwitch(false);
-
-  /*  this->battery_type_text_sensor_ = new text_sensor::TextSensor();
-      this->password_text_sensor_ = new text_sensor::TextSensor();
-      this->info_device_serial_number_text_sensor_ = new text_sensor::TextSensor();
-      this->device_type_text_sensor_ = new text_sensor::TextSensor();
-      this->software_version_text_sensor_ = new text_sensor::TextSensor();
-      this->manufacturer_text_sensor_ = new text_sensor::TextSensor();
-      this->network_nodes_available_text_sensor_ = new text_sensor::TextSensor();
-      this->errors_text_sensor_ = new text_sensor::TextSensor();
-      this->operation_status_text_sensor_ = new text_sensor::TextSensor();
-      this->total_runtime_formatted_text_sensor_ = new text_sensor::TextSensor();
-      this->info_vendorid_text_sensor_ = new text_sensor::TextSensor();
-      this->info_hardware_version_text_sensor_ = new text_sensor::TextSensor();
-      this->info_software_version_text_sensor_ = new text_sensor::TextSensor();
-      this->info_device_name_text_sensor_ = new text_sensor::TextSensor();
-      this->info_device_password_text_sensor_ = new text_sensor::TextSensor();
-      this->info_device_setup_passcode_text_sensor_ = new text_sensor::TextSensor();
-
-      this->balancing_switch_binary_sensor_= new binary_sensor::BinarySensor();
-      this->precharging_switch_binary_sensor_= new binary_sensor::BinarySensor();
-      this->charging_switch_binary_sensor_= new binary_sensor::BinarySensor();
-      this->discharging_switch_binary_sensor_= new binary_sensor::BinarySensor();
-      this->dedicated_charger_switch_binary_sensor_= new binary_sensor::BinarySensor();
-  */
-  this->status_online_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->status_balancing_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->status_precharging_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->status_charging_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->status_discharging_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->status_heating_binary_sensor_ = new binary_sensor::BinarySensor();
-
-  this->alarm_wireres_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_mosotp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_cellquantity_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_cursensorerr_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_cellovp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_batovp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_chocp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_chscp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_chotp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_chutp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_cpuauxcommuerr_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_celluvp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_batuvp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_dchocp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_dchscp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_dchotp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_chargemos_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_dischargemos_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_gpsdisconneted_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_modifypwdintime_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_dischargeonfailed_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_batteryovertemp_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_temperaturesensoranomaly_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_plcmoduleanomaly_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_mostempsensorabsent_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_battempsensor1absent_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_battempsensor2absent_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_battempsensor3absent_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_battempsensor4absent_binary_sensor_ = new binary_sensor::BinarySensor();
-  this->alarm_battempsensor5absent_binary_sensor_ = new binary_sensor::BinarySensor();
-
-  this->battery_total_alarms_count_sensor_ = new sensor::Sensor();
-  this->battery_total_alarms_active_sensor_ = new sensor::Sensor();
-  this->smart_sleep_time_sensor_ = new sensor::Sensor();
-  this->emergency_time_countdown_sensor_ = new sensor::Sensor();
-
-  this->balancing_direction_sensor_ = new sensor::Sensor();
-  this->max_discharging_current_sensor_ = new sensor::Sensor();
-  this->scp_recovery_time_number_ = new sensor::Sensor();
-  this->total_battery_capacity_number_ = new sensor::Sensor();
-
-  this->discharging_overcurrent_protection_release_time_sensor_ = new sensor::Sensor();
-  this->discharging_short_circuit_protection_release_time_sensor_ = new sensor::Sensor();
-  this->charging_overcurrent_protection_release_time_sensor_ = new sensor::Sensor();
-  this->charging_short_circuit_protection_release_time_sensor_ = new sensor::Sensor();
-  this->cell_undervoltage_protection_release_time_sensor_ = new sensor::Sensor();
-  this->cell_overvoltage_protection_release_time_sensor_ = new sensor::Sensor();
-
-  this->cell_count_real_sensor_ = new sensor::Sensor();
-  this->cell_voltage_min_sensor_ = new sensor::Sensor();
-  this->cell_voltage_max_sensor_ = new sensor::Sensor();
-  this->cell_resistance_min_sensor_ = new sensor::Sensor();
-  this->cell_resistance_max_sensor_ = new sensor::Sensor();
-  this->cell_voltage_min_cell_number_sensor_ = new sensor::Sensor();
-  this->cell_voltage_max_cell_number_sensor_ = new sensor::Sensor();
-  this->cell_resistance_min_cell_number_sensor_ = new sensor::Sensor();
-  this->cell_resistance_max_cell_number_sensor_ = new sensor::Sensor();
-  this->cell_delta_voltage_sensor_ = new sensor::Sensor();
-  this->cell_average_voltage_sensor_ = new sensor::Sensor();
-  this->temperature_powertube_sensor_ = new sensor::Sensor();
-  this->temperature_sensor_1_sensor_ = new sensor::Sensor();
-  this->temperature_sensor_2_sensor_ = new sensor::Sensor();
-  this->battery_voltage_sensor_ = new sensor::Sensor();
-  this->battery_current_sensor_ = new sensor::Sensor();
-  this->battery_power_sensor_ = new sensor::Sensor();
-  this->battery_power_charging_sensor_ = new sensor::Sensor();
-  this->battery_power_discharging_sensor_ = new sensor::Sensor();
-  this->battery_capacity_remaining_sensor_ = new sensor::Sensor();
-  this->battery_capacity_remaining_derived_sensor_ = new sensor::Sensor();
-  this->temperature_sensors_sensor_ = new sensor::Sensor();
-  this->charging_cycles_sensor_ = new sensor::Sensor();
-  this->battery_capacity_total_charging_cycle_sensor_ = new sensor::Sensor();
-  this->battery_strings_sensor_ = new sensor::Sensor();
-  this->errors_bitmask_sensor_ = new sensor::Sensor();
-  this->operation_mode_bitmask_sensor_ = new sensor::Sensor();
-  this->cell_voltage_overvoltage_delay_sensor_ = new sensor::Sensor();
-  this->cell_voltage_undervoltage_delay_sensor_ = new sensor::Sensor();
-  this->cell_pressure_difference_protection_sensor_ = new sensor::Sensor();
-  this->discharging_overcurrent_protection_sensor_ = new sensor::Sensor();
-  this->discharging_overcurrent_delay_sensor_ = new sensor::Sensor();
-  this->charging_overcurrent_protection_sensor_ = new sensor::Sensor();
-  this->charging_overcurrent_delay_sensor_ = new sensor::Sensor();
-  this->balancing_opening_pressure_difference_sensor_ = new sensor::Sensor();
-  this->powertube_temperature_protection_sensor_ = new sensor::Sensor();
-  this->powertube_temperature_protection_recovery_sensor_ = new sensor::Sensor();
-  this->temperature_sensor_temperature_protection_sensor_ = new sensor::Sensor();
-  this->temperature_sensor_temperature_recovery_sensor_ = new sensor::Sensor();
-  this->temperature_sensor_temperature_difference_protection_sensor_ = new sensor::Sensor();
-
-  this->battery_soh_valuation_sensor_ = new sensor::Sensor();
-
-  /*this->charging_sensor_= new sensor::Sensor();
-   this->discharging_sensor_= new sensor::Sensor();
-   this->current_calibration_sensor_= new sensor::Sensor();
-   this->device_address_sensor_= new sensor::Sensor();
-   this->sleep_wait_time_sensor_= new sensor::Sensor();
-   this->alarm_low_volume_sensor_= new sensor::Sensor();
-   this->password_sensor_= new sensor::Sensor();
-   this->manufacturing_date_sensor_= new sensor::Sensor();*/
-  this->battery_total_runtime_sensor_ = new sensor::Sensor();
-  /*this->start_current_calibration_sensor_= new sensor::Sensor();
-  this->actual_battery_capacity_sensor_= new sensor::Sensor();
-  this->protocol_version_sensor_= new sensor::Sensor();*/
-
-  this->battery_capacity_state_of_charge_sensor_ = new sensor::Sensor();
-  this->heating_current_sensor_ = new sensor::Sensor();
-  this->balancing_current_sensor_ = new sensor::Sensor();
-  this->uart1_protocol_number_sensor_ = new sensor::Sensor();
-  this->uart2_protocol_number_sensor_ = new sensor::Sensor();
-
-  this->cell_smart_sleep_voltage_number_ = new JkRS485BmsNumber();
-  this->cell_undervoltage_protection_number_ = new JkRS485BmsNumber();
-  this->cell_undervoltage_protection_recovery_number_ = new JkRS485BmsNumber();
-  this->cell_overvoltage_protection_number_ = new JkRS485BmsNumber();
-  this->cell_overvoltage_protection_recovery_number_ = new JkRS485BmsNumber();
-  this->cell_balancing_trigger_voltage_number_ = new JkRS485BmsNumber();
-  this->cell_soc100_voltage_number_ = new JkRS485BmsNumber();
-  this->cell_soc0_voltage_number_ = new JkRS485BmsNumber();
-  this->cell_request_charge_voltage_number_ = new JkRS485BmsNumber();
-  this->cell_request_float_voltage_number_ = new JkRS485BmsNumber();
-  this->cell_power_off_voltage_number_ = new JkRS485BmsNumber();
-  this->cell_balancing_starting_voltage_number_ = new JkRS485BmsNumber();
-  this->max_charging_current_number_ = new JkRS485BmsNumber();
-  this->charging_overcurrent_protection_delay_number_ = new JkRS485BmsNumber();
-  this->charging_overcurrent_protection_recovery_delay_number_ = new JkRS485BmsNumber();
-  this->max_discharging_current_number_ = new JkRS485BmsNumber();
-  this->discharging_overcurrent_protection_delay_number_ = new JkRS485BmsNumber();
-  this->discharging_overcurrent_protection_recovery_delay_number_ = new JkRS485BmsNumber();
-  this->short_circuit_protection_delay_number_ = new JkRS485BmsNumber();
-  this->short_circuit_protection_recovery_delay_number_ = new JkRS485BmsNumber();
-  this->max_balancing_current_number_ = new JkRS485BmsNumber();
-  this->charging_overtemperature_protection_number_ = new JkRS485BmsNumber();
-  this->charging_overtemperature_protection_recovery_number_ = new JkRS485BmsNumber();
-  this->discharging_overtemperature_protection_number_ = new JkRS485BmsNumber();
-  this->discharging_overtemperature_protection_recovery_number_ = new JkRS485BmsNumber();
-  this->charging_lowtemperature_protection_number_ = new JkRS485BmsNumber();
-  this->charging_lowtemperature_protection_recovery_number_ = new JkRS485BmsNumber();
-  this->mos_overtemperature_protection_number_ = new JkRS485BmsNumber();
-  this->mos_overtemperature_protection_recovery_number_ = new JkRS485BmsNumber();
-  this->cell_count_settings_number_ = new JkRS485BmsNumber();
-  this->battery_capacity_total_settings_number_ = new JkRS485BmsNumber();
-  this->precharging_time_from_discharge_number_ = new JkRS485BmsNumber();
-  this->cell_request_charge_voltage_time_number_ = new JkRS485BmsNumber();
-  this->cell_request_float_voltage_time_number_ = new JkRS485BmsNumber();
-
-  for (uint8_t i = 0; i < 32; ++i) {
-    cells_[i].cell_voltage_sensor_ = new sensor::Sensor();
-    cells_[i].cell_resistance_sensor_ = new sensor::Sensor();
-    // cells_[i].cell_voltage3_sensor_ = new sensor::Sensor();
-  }
-
-  for (uint8_t i = 0; i < 32; ++i) {
-    cells_[i].cell_voltage_sensor_ = nullptr;
-    cells_[i].cell_resistance_sensor_ = nullptr;
-  }
-
-  this->arr[0] = 0;
-  this->arr[1] = 0;
-}
-
 void JkRS485Bms::set_disable_pcl_module_switch(JkRS485BmsSwitch *disable_pcl_module_switch) {
   this->disable_pcl_module_switch_ = disable_pcl_module_switch;
 }
@@ -610,8 +403,8 @@ void JkRS485Bms::trigger_bms2sniffer_switch_or_number_uint32_event(std::uint16_t
   //[0x0000, 0x10,   0x04,  3,  0],
 
   // Verificación de `this`
-  if (this == nullptr) {
-    ESP_LOGE(TAG, "switch THIS (this->) is null");
+  if (this->parent_ == nullptr) {
+    ESP_LOGE(TAG, "Sniffer parent is null");
     return;
   }
 
@@ -627,8 +420,8 @@ void JkRS485Bms::trigger_bms2sniffer_switch_or_number_int32_event(std::uint16_t 
   ESP_LOGD(TAG, "Entering trigger_bms2sniffer_switch_or_number_int32_event");
 
   // Verificación de `this`
-  if (this == nullptr) {
-    ESP_LOGE(TAG, "switch THIS (this->) is null");
+  if (this->parent_ == nullptr) {
+    ESP_LOGE(TAG, "Sniffer parent is null");
     return;
   }
 
@@ -654,18 +447,19 @@ void JkRS485Bms::trigger_bms2sniffer_switch16_event(std::uint16_t register_addre
   ESP_LOGD(TAG, "Entering trigger_bms2sniffer_switch16_event");
 
   // Verificación de `this`
-  if (this == nullptr) {
-    ESP_LOGE(TAG, "switch THIS (this->) is null");
+  if (this->parent_ == nullptr) {
+    ESP_LOGE(TAG, "Sniffer parent is null");
     return;
   }
 
   uint16_t value_to_send = 0;
+  auto is_switch_ready = [](JkRS485BmsSwitch *sw) { return sw != nullptr && sw->is_ready(); };
 
-  if ((this->heating_switch_->is_ready()) && (this->disable_temperature_sensors_switch_->is_ready()) &&
-      (this->gps_heartbeat_switch_->is_ready()) && (this->port_selection_switch_->is_ready()) &&
-      (this->display_always_on_switch_->is_ready()) && (this->special_charger_switch_->is_ready()) &&
-      (this->smart_sleep_on_switch_->is_ready()) && (this->disable_pcl_module_switch_->is_ready()) &&
-      (this->timed_stored_data_switch_->is_ready()) && (this->charging_float_mode_switch_->is_ready())) {
+  if (is_switch_ready(this->heating_switch_) && is_switch_ready(this->disable_temperature_sensors_switch_) &&
+      is_switch_ready(this->gps_heartbeat_switch_) && is_switch_ready(this->port_selection_switch_) &&
+      is_switch_ready(this->display_always_on_switch_) && is_switch_ready(this->special_charger_switch_) &&
+      is_switch_ready(this->smart_sleep_on_switch_) && is_switch_ready(this->disable_pcl_module_switch_) &&
+      is_switch_ready(this->timed_stored_data_switch_) && is_switch_ready(this->charging_float_mode_switch_)) {
     value_to_send = this->charging_float_mode_switch_->state;
     value_to_send = (value_to_send << 1) | this->timed_stored_data_switch_->state;
     value_to_send = (value_to_send << 1) | this->disable_pcl_module_switch_->state;
@@ -695,15 +489,16 @@ void JkRS485Bms::trigger_bms2sniffer_number16_event(std::uint16_t register_addre
   ESP_LOGD(TAG, "Entering trigger_bms2sniffer_number16_event");
 
   // Verificación de `this`
-  if (this == nullptr) {
-    ESP_LOGE(TAG, "switch THIS (this->) is null");
+  if (this->parent_ == nullptr) {
+    ESP_LOGE(TAG, "Sniffer parent is null");
     return;
   }
 
   uint16_t value_to_send = 0;
+  auto is_number_ready = [](JkRS485BmsNumber *number) { return number != nullptr && number->is_ready(); };
 
-  if ((this->cell_request_charge_voltage_time_number_->is_ready()) &&
-      (this->cell_request_float_voltage_time_number_->is_ready())) {
+  if (is_number_ready(this->cell_request_charge_voltage_time_number_) &&
+      is_number_ready(this->cell_request_float_voltage_time_number_)) {
     uint8_t high = static_cast<uint8_t>(this->cell_request_charge_voltage_time_number_->state * 10);
     uint8_t low = static_cast<uint8_t>(this->cell_request_float_voltage_time_number_->state * 10);
 
@@ -765,12 +560,14 @@ void JkRS485Bms::on_jk_rs485_sniffer_data(const uint8_t &origin_address, const u
         ESP_LOGD(TAG, "  %s", format_hex_pretty(&data.front(), 150).c_str());
     }
 
-    ESP_LOGD(TAG, "on_jk_rs485_sniffer_data()--this->cell_count_real_sensor_->state: %f ",
-             this->cell_count_real_sensor_->state);
-    ESP_LOGD(TAG, "on_jk_rs485_sniffer_data()--this->cell_count_settings_number_->state: %f ",
-             this->cell_count_settings_number_->state);
+    const float cell_count_real_state =
+        this->cell_count_real_sensor_ != nullptr ? this->cell_count_real_sensor_->state : 0.0f;
+    const float cell_count_settings_state =
+        this->cell_count_settings_number_ != nullptr ? this->cell_count_settings_number_->state : 0.0f;
+    ESP_LOGD(TAG, "on_jk_rs485_sniffer_data()--cell_count_real_state: %f ", cell_count_real_state);
+    ESP_LOGD(TAG, "on_jk_rs485_sniffer_data()--cell_count_settings_state: %f ", cell_count_settings_state);
 
-    if (this->cell_count_real_sensor_->state > 0 && this->cell_count_settings_number_->state > 0) {
+    if (cell_count_real_state > 0 && cell_count_settings_state > 0) {
       ESP_LOGD(TAG, "ONLINE successfull!");
       this->reset_status_online_tracker_();
     } else {
@@ -866,7 +663,10 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
   float cell_voltage;
   float cell_resistance;
 
-  uint8_t cells_from_settings = (uint8_t) this->cell_count_settings_number_->state;
+  uint8_t cells_from_settings = 0;
+  if (this->cell_count_settings_number_ != nullptr) {
+    cells_from_settings = (uint8_t) this->cell_count_settings_number_->state;
+  }
 
   if (cells_from_settings > 0) {
     cells = cells_from_settings;
@@ -1985,8 +1785,8 @@ void JkRS485Bms::publish_state_(sensor::Sensor *sensor, float value) {
 
   ESP_LOGVV(TAG, "Debug point 101 (--> %f)", value);
 
-  if (std::isnan(value) || std::isinf(value)) {
-    ESP_LOGW("JkRS485Bms", "Sensor is invalid NaN or infinite.");
+  if (std::isinf(value)) {
+    ESP_LOGW("JkRS485Bms", "Sensor is invalid infinite.");
     return;
   }
   ESP_LOGVV(TAG, "Debug point 102 (--> %f)", value);
@@ -2210,4 +2010,5 @@ void JkRS485Bms::dump_config() {  // NOLINT(google-readability-function-size,rea
 
 }  // namespace jk_rs485_bms
 }  // namespace esphome
+
 

--- a/components/jk_rs485_bms/jk_rs485_bms.cpp
+++ b/components/jk_rs485_bms/jk_rs485_bms.cpp
@@ -217,9 +217,9 @@ void JkRS485Bms::set_cell_request_float_voltage_time_number(JkRS485BmsNumber *ce
 }
 
 static const char *const TAG = "jk_rs485_bms";
-static const uint32_t SENSOR_PUBLISH_INTERVAL_MS = 10000;
-static const uint32_t NUMBER_PUBLISH_INTERVAL_MS = 10000;
-static const uint32_t TEXT_PUBLISH_INTERVAL_MS = 10000;
+static const uint32_t DEFAULT_SENSOR_PUBLISH_INTERVAL_MS = 10000;
+static const uint32_t DEFAULT_NUMBER_PUBLISH_INTERVAL_MS = 10000;
+static const uint32_t DEFAULT_TEXT_PUBLISH_INTERVAL_MS = 10000;
 
 static const uint8_t MAX_NO_RESPONSE_COUNT = 10;
 
@@ -1814,7 +1814,9 @@ void JkRS485Bms::publish_state_(sensor::Sensor *sensor, float value) {
   }
   ESP_LOGVV(TAG, "Debug point 102 (--> %f)", value);
   const bool force_publish = std::isnan(value);
-  if (!this->should_publish_now_(reinterpret_cast<uintptr_t>(sensor), SENSOR_PUBLISH_INTERVAL_MS, force_publish)) {
+  const uint32_t publish_interval_ms = this->parent_ != nullptr ? this->parent_->get_sensor_publish_interval()
+                                                                 : DEFAULT_SENSOR_PUBLISH_INTERVAL_MS;
+  if (!this->should_publish_now_(reinterpret_cast<uintptr_t>(sensor), publish_interval_ms, force_publish)) {
     return;
   }
   sensor->publish_state(value);
@@ -1855,7 +1857,9 @@ void JkRS485Bms::publish_state_(JkRS485BmsNumber *number, float value) {
 
   if (reinterpret_cast<uintptr_t>(number) > 0x3f000000) {
     const bool force_publish = std::isnan(value);
-    if (!this->should_publish_now_(reinterpret_cast<uintptr_t>(number), NUMBER_PUBLISH_INTERVAL_MS, force_publish)) {
+    const uint32_t publish_interval_ms = this->parent_ != nullptr ? this->parent_->get_number_publish_interval()
+                                                                   : DEFAULT_NUMBER_PUBLISH_INTERVAL_MS;
+    if (!this->should_publish_now_(reinterpret_cast<uintptr_t>(number), publish_interval_ms, force_publish)) {
       return;
     }
     ESP_LOGV(TAG, "       ]* Publishing state %f for object with address %p [%f] %s", value, (void *) number,
@@ -1881,7 +1885,9 @@ void JkRS485Bms::publish_state_(text_sensor::TextSensor *text_sensor, const std:
   }
 
   const bool force_publish = state == "Offline";
-  if (!this->should_publish_now_(reinterpret_cast<uintptr_t>(text_sensor), TEXT_PUBLISH_INTERVAL_MS, force_publish)) {
+  const uint32_t publish_interval_ms = this->parent_ != nullptr ? this->parent_->get_text_publish_interval()
+                                                                 : DEFAULT_TEXT_PUBLISH_INTERVAL_MS;
+  if (!this->should_publish_now_(reinterpret_cast<uintptr_t>(text_sensor), publish_interval_ms, force_publish)) {
     return;
   }
   text_sensor->publish_state(state);

--- a/components/jk_rs485_bms/jk_rs485_bms.cpp
+++ b/components/jk_rs485_bms/jk_rs485_bms.cpp
@@ -560,19 +560,31 @@ void JkRS485Bms::on_jk_rs485_sniffer_data(const uint8_t &origin_address, const u
         ESP_LOGD(TAG, "  %s", format_hex_pretty(&data.front(), 150).c_str());
     }
 
+    const bool has_cell_count_real_sensor = this->cell_count_real_sensor_ != nullptr;
+    const bool has_cell_count_settings_number = this->cell_count_settings_number_ != nullptr;
     const float cell_count_real_state =
-        this->cell_count_real_sensor_ != nullptr ? this->cell_count_real_sensor_->state : 0.0f;
+        has_cell_count_real_sensor ? this->cell_count_real_sensor_->state : 0.0f;
     const float cell_count_settings_state =
-        this->cell_count_settings_number_ != nullptr ? this->cell_count_settings_number_->state : 0.0f;
+        has_cell_count_settings_number ? this->cell_count_settings_number_->state : 0.0f;
     ESP_LOGD(TAG, "on_jk_rs485_sniffer_data()--cell_count_real_state: %f ", cell_count_real_state);
     ESP_LOGD(TAG, "on_jk_rs485_sniffer_data()--cell_count_settings_state: %f ", cell_count_settings_state);
+    ESP_LOGD(TAG, "on_jk_rs485_sniffer_data()--has_cell_count_settings_number: %d ",
+             has_cell_count_settings_number);
 
-    if (cell_count_real_state > 0 && cell_count_settings_state > 0) {
+    const bool has_required_online_data =
+        cell_count_real_state > 0 && (!has_cell_count_settings_number || cell_count_settings_state > 0);
+
+    if (has_required_online_data) {
       ESP_LOGD(TAG, "ONLINE successfull!");
       this->reset_status_online_tracker_();
     } else {
-      ESP_LOGI(TAG, "Cannot set ONLINE until arrived both 0x01 and 0x02 frame types");
-      ESP_LOGD(TAG, "Cannot set ONLINE until arrived both 0x01 and 0x02 frame types");
+      if (has_cell_count_settings_number) {
+        ESP_LOGI(TAG, "Cannot set ONLINE until arrived both 0x01 and 0x02 frame types");
+        ESP_LOGD(TAG, "Cannot set ONLINE until arrived both 0x01 and 0x02 frame types");
+      } else {
+        ESP_LOGI(TAG, "Cannot set ONLINE until arrived frame type 0x02 with valid cell count");
+        ESP_LOGD(TAG, "Cannot set ONLINE until arrived frame type 0x02 with valid cell count");
+      }
     }
 
   } else {

--- a/components/jk_rs485_bms/jk_rs485_bms.cpp
+++ b/components/jk_rs485_bms/jk_rs485_bms.cpp
@@ -600,9 +600,17 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
 
   uint8_t frame_version = FRAME_VERSION_JK02_32S;
   uint8_t offset = 16;
+  const size_t max_required_index = 226 + (offset * 2);
  
   // ESP_LOGD(TAG, "Decoding cell info frame.... [ADDRESS: %02X] %d bytes received", this->address_, data.size());
   ESP_LOGI(TAG, "Decoding cell info frame.... [ADDRESS: %02X] %d bytes received", this->address_, data.size());
+
+  if (data.size() <= max_required_index) {
+    ESP_LOGE(TAG,
+             "JkRS485Bms::decode_jk02_cell_info_() #error:frame_too_short #size:%u #required_min:%u--<",
+             static_cast<unsigned>(data.size()), static_cast<unsigned>(max_required_index + 1));
+    return;
+  }
 
   // ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front(), 150).c_str());
   // ESP_LOGVV(TAG, "  %s", format_hex_pretty(&data.front() + 150, data.size() - 150).c_str());
@@ -670,6 +678,13 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
 
   if (cells_from_settings > 0) {
     cells = cells_from_settings;
+  }
+
+  if (cells > sizeof(this->cells_) / sizeof(this->cells_[0])) {
+    ESP_LOGW(TAG, "JkRS485Bms::decode_jk02_cell_info_() #cells_clamped:%u #max:%u",
+             static_cast<unsigned>(cells),
+             static_cast<unsigned>(sizeof(this->cells_) / sizeof(this->cells_[0])));
+    cells = sizeof(this->cells_) / sizeof(this->cells_[0]);
   }
 
   ESP_LOGD(TAG, "JkRS485Bms::decode_jk02_cell_info_: 1");

--- a/components/jk_rs485_bms/jk_rs485_bms.cpp
+++ b/components/jk_rs485_bms/jk_rs485_bms.cpp
@@ -529,7 +529,8 @@ void JkRS485Bms::on_jk_rs485_sniffer_data(const uint8_t &origin_address, const u
 
   if (this->nodes_available != nodes_available_received) {
     this->nodes_available = nodes_available_received;
-    this->publish_state_(this->network_nodes_available_text_sensor_, this->nodes_available);
+    this->network_nodes_available_dirty_ = true;
+    this->flush_network_nodes_available_();
   }
 
   if (origin_address == this->address_) {
@@ -1570,7 +1571,10 @@ void JkRS485Bms::decode_jk02_settings_(const std::vector<uint8_t> &data) {
   this->trigger_bms2sniffer_event("WORKING ! #####", 01);
 }
 
-void JkRS485Bms::update() { this->track_status_online_(); }
+void JkRS485Bms::update() {
+  this->track_status_online_();
+  this->flush_network_nodes_available_();
+}
 
 void JkRS485Bms::decode_device_info_(const std::vector<uint8_t> &data) {
 
@@ -1790,6 +1794,26 @@ bool JkRS485Bms::should_publish_now_(uintptr_t key, uint32_t interval_ms, bool f
   }
 
   return false;
+}
+
+void JkRS485Bms::flush_network_nodes_available_() {
+  if (!this->network_nodes_available_dirty_) {
+    return;
+  }
+
+  if (this->network_nodes_available_text_sensor_ == nullptr) {
+    return;
+  }
+
+  const uint32_t publish_interval_ms = this->parent_ != nullptr ? this->parent_->get_text_publish_interval()
+                                                                 : DEFAULT_TEXT_PUBLISH_INTERVAL_MS;
+  const uintptr_t key = reinterpret_cast<uintptr_t>(this->network_nodes_available_text_sensor_);
+  if (!this->should_publish_now_(key, publish_interval_ms, false)) {
+    return;
+  }
+
+  this->network_nodes_available_text_sensor_->publish_state(this->nodes_available);
+  this->network_nodes_available_dirty_ = false;
 }
 
 // void JkRS485Bms::publish_state_(sensor::Sensor *sensor, float value) {

--- a/components/jk_rs485_bms/jk_rs485_bms.cpp
+++ b/components/jk_rs485_bms/jk_rs485_bms.cpp
@@ -975,12 +975,12 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
       this->publish_state_(this->battery_soh_valuation_sensor_,
                            temp_param_value);  //  (float) jk_get_32bit(158 + offset));
 
-      ESP_LOGD(TAG, " ===============================================================================================");
-      ESP_LOGD(TAG, " block C");
+      // ESP_LOGD(TAG, " ===============================================================================================");
+      // ESP_LOGD(TAG, " block C");
 
-      offset = offset * 2;  // Copy the offset from the previous conditional.
+      // //offset = offset * 2;  // Copy the offset from the previous conditional.
 
-      ESP_LOGD(TAG, " block C - offset: %d) ", offset);
+      // ESP_LOGD(TAG, " block C - offset: %d) ", offset);
 
       // 159  [185=159+26]  1   0x00                   Precharge
       // ESP_LOGV(TAG, "Precharge: 0x%02X (always 0x00?)", data[159 + offset]);

--- a/components/jk_rs485_bms/jk_rs485_bms.cpp
+++ b/components/jk_rs485_bms/jk_rs485_bms.cpp
@@ -876,10 +876,9 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
           int16_to_float(&data[134 + offset]) * 0.1f);  //  (float) ((int16_t) jk_get_16bit(134 + offset)) * 0.1f);
     }
 
-      ESP_LOGD(TAG, " ===============================================================================================");
-      ESP_LOGD(TAG, " block B - offset: %d) ", offset);
-
-      offset = offset * 2;
+      // ESP_LOGD(TAG, " ===============================================================================================");
+      // ESP_LOGD(TAG, " block B - offset: %d) ", offset);
+      // offset = offset * 2;
 
       // 135 [161=135+26]   2   0xD2        Alarms      bit
       // AlarmChOTP                  1   (0:normal | 1:alarm)
@@ -977,7 +976,6 @@ void JkRS485Bms::decode_jk02_cell_info_(const std::vector<uint8_t> &data) {
 
       // ESP_LOGD(TAG, " ===============================================================================================");
       // ESP_LOGD(TAG, " block C");
-
       // //offset = offset * 2;  // Copy the offset from the previous conditional.
 
       // ESP_LOGD(TAG, " block C - offset: %d) ", offset);

--- a/components/jk_rs485_bms/jk_rs485_bms.cpp
+++ b/components/jk_rs485_bms/jk_rs485_bms.cpp
@@ -529,8 +529,7 @@ void JkRS485Bms::on_jk_rs485_sniffer_data(const uint8_t &origin_address, const u
 
   if (this->nodes_available != nodes_available_received) {
     this->nodes_available = nodes_available_received;
-    this->network_nodes_available_dirty_ = true;
-    this->flush_network_nodes_available_();
+    this->publish_state_(this->network_nodes_available_text_sensor_, this->nodes_available);
   }
 
   if (origin_address == this->address_) {
@@ -1571,10 +1570,7 @@ void JkRS485Bms::decode_jk02_settings_(const std::vector<uint8_t> &data) {
   this->trigger_bms2sniffer_event("WORKING ! #####", 01);
 }
 
-void JkRS485Bms::update() {
-  this->track_status_online_();
-  this->flush_network_nodes_available_();
-}
+void JkRS485Bms::update() { this->track_status_online_(); }
 
 void JkRS485Bms::decode_device_info_(const std::vector<uint8_t> &data) {
 
@@ -1794,26 +1790,6 @@ bool JkRS485Bms::should_publish_now_(uintptr_t key, uint32_t interval_ms, bool f
   }
 
   return false;
-}
-
-void JkRS485Bms::flush_network_nodes_available_() {
-  if (!this->network_nodes_available_dirty_) {
-    return;
-  }
-
-  if (this->network_nodes_available_text_sensor_ == nullptr) {
-    return;
-  }
-
-  const uint32_t publish_interval_ms = this->parent_ != nullptr ? this->parent_->get_text_publish_interval()
-                                                                 : DEFAULT_TEXT_PUBLISH_INTERVAL_MS;
-  const uintptr_t key = reinterpret_cast<uintptr_t>(this->network_nodes_available_text_sensor_);
-  if (!this->should_publish_now_(key, publish_interval_ms, false)) {
-    return;
-  }
-
-  this->network_nodes_available_text_sensor_->publish_state(this->nodes_available);
-  this->network_nodes_available_dirty_ = false;
 }
 
 // void JkRS485Bms::publish_state_(sensor::Sensor *sensor, float value) {

--- a/components/jk_rs485_bms/jk_rs485_bms.h
+++ b/components/jk_rs485_bms/jk_rs485_bms.h
@@ -54,9 +54,6 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
   virtual ~JkRS485Bms() = default; // Destructor por defecto
 
 
-  void JkRS485Bms_init(void);
-
-
   void set_sniffer_parent(jk_rs485_sniffer::JkRS485Sniffer *parent);
   
   jk_rs485_sniffer::JkRS485Sniffer* get_sniffer_parent(void); // Nuevo método para obtener el parent
@@ -668,7 +665,7 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
   //bool write_register(uint8_t address, uint32_t value, uint8_t length);
 
  protected:
-  jk_rs485_sniffer::JkRS485Sniffer *parent_;
+  jk_rs485_sniffer::JkRS485Sniffer *parent_{nullptr};
   ProtocolVersion protocol_version_{PROTOCOL_VERSION_JK02_32S};
 
   uint8_t address_;
@@ -678,13 +675,13 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
   //std::vector<JkRS485BmsSwitch *> switches_; 
 
   struct CellInfo {
-    sensor::Sensor* cell_voltage_sensor_;  // Puntero al sensor de voltaje
-    sensor::Sensor* cell_resistance_sensor_;  // Puntero al sensor de resistencia
+    sensor::Sensor* cell_voltage_sensor_{nullptr};  // Puntero al sensor de voltaje
+    sensor::Sensor* cell_resistance_sensor_{nullptr};  // Puntero al sensor de resistencia
   };  
 
   struct CellInformation {
-    sensor::Sensor *cell_voltage_sensor_; 
-    sensor::Sensor *cell_resistance_sensor_; 
+    sensor::Sensor *cell_voltage_sensor_{nullptr};
+    sensor::Sensor *cell_resistance_sensor_{nullptr};
   };
   struct Temperature {
     sensor::Sensor *temperature_sensor_{nullptr};
@@ -771,228 +768,228 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
   private:
     int arr[2] = {0, 0};
     
-    JkRS485BmsSwitch *precharging_switch_;
-    JkRS485BmsSwitch *charging_switch_;
-    JkRS485BmsSwitch *discharging_switch_;
-    JkRS485BmsSwitch *balancer_switch_;
-    JkRS485BmsSwitch *emergency_switch_;
-    JkRS485BmsSwitch *heating_switch_;
-    JkRS485BmsSwitch *charging_float_mode_switch_;
-    JkRS485BmsSwitch *disable_temperature_sensors_switch_;
-    JkRS485BmsSwitch *display_always_on_switch_;
-    JkRS485BmsSwitch *smart_sleep_on_switch_;
-    JkRS485BmsSwitch *timed_stored_data_switch_;
-    JkRS485BmsSwitch *disable_pcl_module_switch_;
-    JkRS485BmsSwitch *gps_heartbeat_switch_;
-    JkRS485BmsSwitch *port_selection_switch_;
-    JkRS485BmsSwitch *special_charger_switch_;  
+    JkRS485BmsSwitch *precharging_switch_{nullptr};
+    JkRS485BmsSwitch *charging_switch_{nullptr};
+    JkRS485BmsSwitch *discharging_switch_{nullptr};
+    JkRS485BmsSwitch *balancer_switch_{nullptr};
+    JkRS485BmsSwitch *emergency_switch_{nullptr};
+    JkRS485BmsSwitch *heating_switch_{nullptr};
+    JkRS485BmsSwitch *charging_float_mode_switch_{nullptr};
+    JkRS485BmsSwitch *disable_temperature_sensors_switch_{nullptr};
+    JkRS485BmsSwitch *display_always_on_switch_{nullptr};
+    JkRS485BmsSwitch *smart_sleep_on_switch_{nullptr};
+    JkRS485BmsSwitch *timed_stored_data_switch_{nullptr};
+    JkRS485BmsSwitch *disable_pcl_module_switch_{nullptr};
+    JkRS485BmsSwitch *gps_heartbeat_switch_{nullptr};
+    JkRS485BmsSwitch *port_selection_switch_{nullptr};
+    JkRS485BmsSwitch *special_charger_switch_{nullptr};
 
-    text_sensor::TextSensor *battery_type_text_sensor_;
-    text_sensor::TextSensor *password_text_sensor_;
-    text_sensor::TextSensor *info_device_serial_number_text_sensor_;
-    text_sensor::TextSensor *device_type_text_sensor_;
-    text_sensor::TextSensor *software_version_text_sensor_;
-    text_sensor::TextSensor *manufacturer_text_sensor_;
-    text_sensor::TextSensor *network_nodes_available_text_sensor_;
-    text_sensor::TextSensor *errors_text_sensor_;
-    text_sensor::TextSensor *operation_status_text_sensor_;
-    text_sensor::TextSensor *total_runtime_formatted_text_sensor_;
-    text_sensor::TextSensor *info_vendorid_text_sensor_;
-    text_sensor::TextSensor *info_hardware_version_text_sensor_;
-    text_sensor::TextSensor *info_software_version_text_sensor_;
-    text_sensor::TextSensor *info_device_name_text_sensor_;
-    text_sensor::TextSensor *info_device_password_text_sensor_;
-    text_sensor::TextSensor *info_device_setup_passcode_text_sensor_;
+    text_sensor::TextSensor *battery_type_text_sensor_{nullptr};
+    text_sensor::TextSensor *password_text_sensor_{nullptr};
+    text_sensor::TextSensor *info_device_serial_number_text_sensor_{nullptr};
+    text_sensor::TextSensor *device_type_text_sensor_{nullptr};
+    text_sensor::TextSensor *software_version_text_sensor_{nullptr};
+    text_sensor::TextSensor *manufacturer_text_sensor_{nullptr};
+    text_sensor::TextSensor *network_nodes_available_text_sensor_{nullptr};
+    text_sensor::TextSensor *errors_text_sensor_{nullptr};
+    text_sensor::TextSensor *operation_status_text_sensor_{nullptr};
+    text_sensor::TextSensor *total_runtime_formatted_text_sensor_{nullptr};
+    text_sensor::TextSensor *info_vendorid_text_sensor_{nullptr};
+    text_sensor::TextSensor *info_hardware_version_text_sensor_{nullptr};
+    text_sensor::TextSensor *info_software_version_text_sensor_{nullptr};
+    text_sensor::TextSensor *info_device_name_text_sensor_{nullptr};
+    text_sensor::TextSensor *info_device_password_text_sensor_{nullptr};
+    text_sensor::TextSensor *info_device_setup_passcode_text_sensor_{nullptr};
 
-    binary_sensor::BinarySensor *balancing_switch_binary_sensor_;
-    binary_sensor::BinarySensor *precharging_switch_binary_sensor_;
-    binary_sensor::BinarySensor *charging_switch_binary_sensor_;
-    binary_sensor::BinarySensor *discharging_switch_binary_sensor_;
-    binary_sensor::BinarySensor *dedicated_charger_switch_binary_sensor_;
+    binary_sensor::BinarySensor *balancing_switch_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *precharging_switch_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *charging_switch_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *discharging_switch_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *dedicated_charger_switch_binary_sensor_{nullptr};
 
-    binary_sensor::BinarySensor *status_online_binary_sensor_;
-    binary_sensor::BinarySensor *status_balancing_binary_sensor_;
-    binary_sensor::BinarySensor *status_precharging_binary_sensor_;  
-    binary_sensor::BinarySensor *status_charging_binary_sensor_;
-    binary_sensor::BinarySensor *status_discharging_binary_sensor_;
-    binary_sensor::BinarySensor *status_heating_binary_sensor_;
+    binary_sensor::BinarySensor *status_online_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *status_balancing_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *status_precharging_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *status_charging_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *status_discharging_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *status_heating_binary_sensor_{nullptr};
 
-    binary_sensor::BinarySensor *alarm_wireres_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_mosotp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_cellquantity_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_cursensorerr_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_cellovp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_batovp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_chocp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_chscp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_chotp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_chutp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_cpuauxcommuerr_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_celluvp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_batuvp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_dchocp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_dchscp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_dchotp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_chargemos_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_dischargemos_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_gpsdisconneted_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_modifypwdintime_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_dischargeonfailed_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_batteryovertemp_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_temperaturesensoranomaly_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_plcmoduleanomaly_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_mostempsensorabsent_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_battempsensor1absent_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_battempsensor2absent_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_battempsensor3absent_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_battempsensor4absent_binary_sensor_;
-    binary_sensor::BinarySensor *alarm_battempsensor5absent_binary_sensor_;
+    binary_sensor::BinarySensor *alarm_wireres_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_mosotp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_cellquantity_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_cursensorerr_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_cellovp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_batovp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_chocp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_chscp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_chotp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_chutp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_cpuauxcommuerr_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_celluvp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_batuvp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_dchocp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_dchscp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_dchotp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_chargemos_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_dischargemos_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_gpsdisconneted_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_modifypwdintime_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_dischargeonfailed_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_batteryovertemp_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_temperaturesensoranomaly_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_plcmoduleanomaly_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_mostempsensorabsent_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_battempsensor1absent_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_battempsensor2absent_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_battempsensor3absent_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_battempsensor4absent_binary_sensor_{nullptr};
+    binary_sensor::BinarySensor *alarm_battempsensor5absent_binary_sensor_{nullptr};
 
-    sensor::Sensor *battery_total_alarms_count_sensor_;
-    sensor::Sensor *battery_total_alarms_active_sensor_;
-    sensor::Sensor *smart_sleep_time_sensor_;
-    sensor::Sensor *emergency_time_countdown_sensor_;
+    sensor::Sensor *battery_total_alarms_count_sensor_{nullptr};
+    sensor::Sensor *battery_total_alarms_active_sensor_{nullptr};
+    sensor::Sensor *smart_sleep_time_sensor_{nullptr};
+    sensor::Sensor *emergency_time_countdown_sensor_{nullptr};
 
 
 
-    sensor::Sensor *balancing_direction_sensor_;  
-    sensor::Sensor *max_discharging_current_sensor_;
-    sensor::Sensor *charging_overcurrent_protection_delay_sensor_;
-    sensor::Sensor *charging_overcurrent_protection_recovery_delay_sensor_;  
-    sensor::Sensor *discharging_overcurrent_protection_delay_sensor_;
-    sensor::Sensor *discharging_overcurrent_protection_recovery_delay_sensor_;  
-    sensor::Sensor *short_circuit_protection_delay_sensor_;
-    sensor::Sensor *short_circuit_protection_recovery_delay_sensor_;
-    sensor::Sensor *charging_overtemperature_protection_sensor_;
-    sensor::Sensor *charging_overtemperature_protection_recovery_sensor_;
-    sensor::Sensor *discharging_overtemperature_protection_sensor_;
-    sensor::Sensor *discharging_overtemperature_protection_recovery_sensor_;
-    sensor::Sensor *charging_lowtemperature_protection_sensor_;
-    sensor::Sensor *charging_lowtemperature_protection_recovery_sensor_;
-    sensor::Sensor *mos_overtemperature_protection_sensor_;
-    sensor::Sensor *mos_overtemperature_protection_recovery_sensor_;  
-    sensor::Sensor *scp_recovery_time_number_;    
-    sensor::Sensor *total_battery_capacity_number_;  
+    sensor::Sensor *balancing_direction_sensor_{nullptr};
+    sensor::Sensor *max_discharging_current_sensor_{nullptr};
+    sensor::Sensor *charging_overcurrent_protection_delay_sensor_{nullptr};
+    sensor::Sensor *charging_overcurrent_protection_recovery_delay_sensor_{nullptr};
+    sensor::Sensor *discharging_overcurrent_protection_delay_sensor_{nullptr};
+    sensor::Sensor *discharging_overcurrent_protection_recovery_delay_sensor_{nullptr};
+    sensor::Sensor *short_circuit_protection_delay_sensor_{nullptr};
+    sensor::Sensor *short_circuit_protection_recovery_delay_sensor_{nullptr};
+    sensor::Sensor *charging_overtemperature_protection_sensor_{nullptr};
+    sensor::Sensor *charging_overtemperature_protection_recovery_sensor_{nullptr};
+    sensor::Sensor *discharging_overtemperature_protection_sensor_{nullptr};
+    sensor::Sensor *discharging_overtemperature_protection_recovery_sensor_{nullptr};
+    sensor::Sensor *charging_lowtemperature_protection_sensor_{nullptr};
+    sensor::Sensor *charging_lowtemperature_protection_recovery_sensor_{nullptr};
+    sensor::Sensor *mos_overtemperature_protection_sensor_{nullptr};
+    sensor::Sensor *mos_overtemperature_protection_recovery_sensor_{nullptr};
+    sensor::Sensor *scp_recovery_time_number_{nullptr};
+    sensor::Sensor *total_battery_capacity_number_{nullptr};
 
-    sensor::Sensor *discharging_overcurrent_protection_release_time_sensor_;
-    sensor::Sensor *discharging_short_circuit_protection_release_time_sensor_;
-    sensor::Sensor *charging_overcurrent_protection_release_time_sensor_;
-    sensor::Sensor *charging_short_circuit_protection_release_time_sensor_;
-    sensor::Sensor *cell_undervoltage_protection_release_time_sensor_;
-    sensor::Sensor *cell_overvoltage_protection_release_time_sensor_;
+    sensor::Sensor *discharging_overcurrent_protection_release_time_sensor_{nullptr};
+    sensor::Sensor *discharging_short_circuit_protection_release_time_sensor_{nullptr};
+    sensor::Sensor *charging_overcurrent_protection_release_time_sensor_{nullptr};
+    sensor::Sensor *charging_short_circuit_protection_release_time_sensor_{nullptr};
+    sensor::Sensor *cell_undervoltage_protection_release_time_sensor_{nullptr};
+    sensor::Sensor *cell_overvoltage_protection_release_time_sensor_{nullptr};
 
-    sensor::Sensor *cell_count_real_sensor_;
-    sensor::Sensor *cell_voltage_min_sensor_;
-    sensor::Sensor *cell_voltage_max_sensor_;
-    sensor::Sensor *cell_resistance_min_sensor_;
-    sensor::Sensor *cell_resistance_max_sensor_;  
-    sensor::Sensor *cell_voltage_min_cell_number_sensor_;
-    sensor::Sensor *cell_voltage_max_cell_number_sensor_;
-    sensor::Sensor *cell_resistance_min_cell_number_sensor_;
-    sensor::Sensor *cell_resistance_max_cell_number_sensor_;  
-    sensor::Sensor *cell_delta_voltage_sensor_;
-    sensor::Sensor *cell_average_voltage_sensor_;
-    sensor::Sensor *temperature_powertube_sensor_;
-    sensor::Sensor *temperature_sensor_1_sensor_;
-    sensor::Sensor *temperature_sensor_2_sensor_;
-    sensor::Sensor *battery_voltage_sensor_;
-    sensor::Sensor *battery_current_sensor_;
-    sensor::Sensor *battery_power_sensor_;
-    sensor::Sensor *battery_power_charging_sensor_;
-    sensor::Sensor *battery_power_discharging_sensor_;
-    sensor::Sensor *battery_capacity_remaining_sensor_;
-    sensor::Sensor *battery_capacity_remaining_derived_sensor_;
-    sensor::Sensor *temperature_sensors_sensor_;
-    sensor::Sensor *charging_cycles_sensor_;
-    sensor::Sensor *battery_capacity_total_charging_cycle_sensor_;
-    sensor::Sensor *battery_strings_sensor_;
-    sensor::Sensor *errors_bitmask_sensor_;
-    sensor::Sensor *operation_mode_bitmask_sensor_;
-    sensor::Sensor *total_voltage_overvoltage_protection_sensor_;
-    sensor::Sensor *total_voltage_undervoltage_protection_sensor_;
-    sensor::Sensor *cell_voltage_overvoltage_delay_sensor_;
-    sensor::Sensor *cell_voltage_undervoltage_delay_sensor_;
-    sensor::Sensor *cell_pressure_difference_protection_sensor_;
-    sensor::Sensor *discharging_overcurrent_protection_sensor_;
-    sensor::Sensor *discharging_overcurrent_delay_sensor_;
-    sensor::Sensor *charging_overcurrent_protection_sensor_;
-    sensor::Sensor *charging_overcurrent_delay_sensor_;
-    sensor::Sensor *cell_balancing_starting_voltage_sensor_;
-    sensor::Sensor *balancing_opening_pressure_difference_sensor_;
-    sensor::Sensor *powertube_temperature_protection_sensor_;
-    sensor::Sensor *powertube_temperature_protection_recovery_sensor_;
-    sensor::Sensor *temperature_sensor_temperature_protection_sensor_;
-    sensor::Sensor *temperature_sensor_temperature_recovery_sensor_;
-    sensor::Sensor *temperature_sensor_temperature_difference_protection_sensor_;
-    sensor::Sensor *charging_high_temperature_protection_sensor_;
-    sensor::Sensor *discharging_high_temperature_protection_sensor_;
-    sensor::Sensor *charging_low_temperature_protection_sensor_;
-    sensor::Sensor *charging_low_temperature_recovery_sensor_;
-    sensor::Sensor *discharging_low_temperature_protection_sensor_;
-    sensor::Sensor *discharging_low_temperature_recovery_sensor_;
-    sensor::Sensor *battery_capacity_total_setting_sensor_;
-    sensor::Sensor *battery_soh_valuation_sensor_;
+    sensor::Sensor *cell_count_real_sensor_{nullptr};
+    sensor::Sensor *cell_voltage_min_sensor_{nullptr};
+    sensor::Sensor *cell_voltage_max_sensor_{nullptr};
+    sensor::Sensor *cell_resistance_min_sensor_{nullptr};
+    sensor::Sensor *cell_resistance_max_sensor_{nullptr};
+    sensor::Sensor *cell_voltage_min_cell_number_sensor_{nullptr};
+    sensor::Sensor *cell_voltage_max_cell_number_sensor_{nullptr};
+    sensor::Sensor *cell_resistance_min_cell_number_sensor_{nullptr};
+    sensor::Sensor *cell_resistance_max_cell_number_sensor_{nullptr};
+    sensor::Sensor *cell_delta_voltage_sensor_{nullptr};
+    sensor::Sensor *cell_average_voltage_sensor_{nullptr};
+    sensor::Sensor *temperature_powertube_sensor_{nullptr};
+    sensor::Sensor *temperature_sensor_1_sensor_{nullptr};
+    sensor::Sensor *temperature_sensor_2_sensor_{nullptr};
+    sensor::Sensor *battery_voltage_sensor_{nullptr};
+    sensor::Sensor *battery_current_sensor_{nullptr};
+    sensor::Sensor *battery_power_sensor_{nullptr};
+    sensor::Sensor *battery_power_charging_sensor_{nullptr};
+    sensor::Sensor *battery_power_discharging_sensor_{nullptr};
+    sensor::Sensor *battery_capacity_remaining_sensor_{nullptr};
+    sensor::Sensor *battery_capacity_remaining_derived_sensor_{nullptr};
+    sensor::Sensor *temperature_sensors_sensor_{nullptr};
+    sensor::Sensor *charging_cycles_sensor_{nullptr};
+    sensor::Sensor *battery_capacity_total_charging_cycle_sensor_{nullptr};
+    sensor::Sensor *battery_strings_sensor_{nullptr};
+    sensor::Sensor *errors_bitmask_sensor_{nullptr};
+    sensor::Sensor *operation_mode_bitmask_sensor_{nullptr};
+    sensor::Sensor *total_voltage_overvoltage_protection_sensor_{nullptr};
+    sensor::Sensor *total_voltage_undervoltage_protection_sensor_{nullptr};
+    sensor::Sensor *cell_voltage_overvoltage_delay_sensor_{nullptr};
+    sensor::Sensor *cell_voltage_undervoltage_delay_sensor_{nullptr};
+    sensor::Sensor *cell_pressure_difference_protection_sensor_{nullptr};
+    sensor::Sensor *discharging_overcurrent_protection_sensor_{nullptr};
+    sensor::Sensor *discharging_overcurrent_delay_sensor_{nullptr};
+    sensor::Sensor *charging_overcurrent_protection_sensor_{nullptr};
+    sensor::Sensor *charging_overcurrent_delay_sensor_{nullptr};
+    sensor::Sensor *cell_balancing_starting_voltage_sensor_{nullptr};
+    sensor::Sensor *balancing_opening_pressure_difference_sensor_{nullptr};
+    sensor::Sensor *powertube_temperature_protection_sensor_{nullptr};
+    sensor::Sensor *powertube_temperature_protection_recovery_sensor_{nullptr};
+    sensor::Sensor *temperature_sensor_temperature_protection_sensor_{nullptr};
+    sensor::Sensor *temperature_sensor_temperature_recovery_sensor_{nullptr};
+    sensor::Sensor *temperature_sensor_temperature_difference_protection_sensor_{nullptr};
+    sensor::Sensor *charging_high_temperature_protection_sensor_{nullptr};
+    sensor::Sensor *discharging_high_temperature_protection_sensor_{nullptr};
+    sensor::Sensor *charging_low_temperature_protection_sensor_{nullptr};
+    sensor::Sensor *charging_low_temperature_recovery_sensor_{nullptr};
+    sensor::Sensor *discharging_low_temperature_protection_sensor_{nullptr};
+    sensor::Sensor *discharging_low_temperature_recovery_sensor_{nullptr};
+    sensor::Sensor *battery_capacity_total_setting_sensor_{nullptr};
+    sensor::Sensor *battery_soh_valuation_sensor_{nullptr};
 
-    sensor::Sensor *charging_sensor_;
-    sensor::Sensor *discharging_sensor_;
-    sensor::Sensor *current_calibration_sensor_;
-    sensor::Sensor *device_address_sensor_;
-    sensor::Sensor *sleep_wait_time_sensor_;
-    sensor::Sensor *alarm_low_volume_sensor_;
-    sensor::Sensor *password_sensor_;
-    sensor::Sensor *manufacturing_date_sensor_;
-    sensor::Sensor *battery_total_runtime_sensor_;
-    sensor::Sensor *start_current_calibration_sensor_;
-    sensor::Sensor *actual_battery_capacity_sensor_;
-    sensor::Sensor *protocol_version_sensor_;
+    sensor::Sensor *charging_sensor_{nullptr};
+    sensor::Sensor *discharging_sensor_{nullptr};
+    sensor::Sensor *current_calibration_sensor_{nullptr};
+    sensor::Sensor *device_address_sensor_{nullptr};
+    sensor::Sensor *sleep_wait_time_sensor_{nullptr};
+    sensor::Sensor *alarm_low_volume_sensor_{nullptr};
+    sensor::Sensor *password_sensor_{nullptr};
+    sensor::Sensor *manufacturing_date_sensor_{nullptr};
+    sensor::Sensor *battery_total_runtime_sensor_{nullptr};
+    sensor::Sensor *start_current_calibration_sensor_{nullptr};
+    sensor::Sensor *actual_battery_capacity_sensor_{nullptr};
+    sensor::Sensor *protocol_version_sensor_{nullptr};
 
-    sensor::Sensor *battery_capacity_state_of_charge_sensor_;
-    sensor::Sensor *heating_current_sensor_;
-    sensor::Sensor *balancing_current_sensor_;
-    sensor::Sensor *uart1_protocol_number_sensor_;
-    sensor::Sensor *uart2_protocol_number_sensor_;  
+    sensor::Sensor *battery_capacity_state_of_charge_sensor_{nullptr};
+    sensor::Sensor *heating_current_sensor_{nullptr};
+    sensor::Sensor *balancing_current_sensor_{nullptr};
+    sensor::Sensor *uart1_protocol_number_sensor_{nullptr};
+    sensor::Sensor *uart2_protocol_number_sensor_{nullptr};
 
 
 
 
     
-    JkRS485BmsNumber *cell_smart_sleep_voltage_number_;
-    JkRS485BmsNumber *cell_undervoltage_protection_number_;  
-    JkRS485BmsNumber *cell_undervoltage_protection_recovery_number_;    
-    JkRS485BmsNumber *cell_overvoltage_protection_number_;  
-    JkRS485BmsNumber *cell_overvoltage_protection_recovery_number_; 
-    JkRS485BmsNumber *cell_balancing_trigger_voltage_number_; 
-    JkRS485BmsNumber *cell_soc100_voltage_number_;
-    JkRS485BmsNumber *cell_soc0_voltage_number_; 
-    JkRS485BmsNumber *cell_request_charge_voltage_number_; 
-    JkRS485BmsNumber *cell_request_float_voltage_number_; 
-    JkRS485BmsNumber *cell_power_off_voltage_number_;
-    JkRS485BmsNumber *cell_balancing_starting_voltage_number_;
-    JkRS485BmsNumber *max_charging_current_number_;    
-    JkRS485BmsNumber *charging_overcurrent_protection_delay_number_;  
-    JkRS485BmsNumber *charging_overcurrent_protection_recovery_delay_number_;  
-    JkRS485BmsNumber *max_discharging_current_number_;    
-    JkRS485BmsNumber *discharging_overcurrent_protection_delay_number_;  
-    JkRS485BmsNumber *discharging_overcurrent_protection_recovery_delay_number_;  
-    JkRS485BmsNumber *short_circuit_protection_delay_number_;     
-    JkRS485BmsNumber *short_circuit_protection_recovery_delay_number_; 
-    JkRS485BmsNumber *max_balancing_current_number_; 
+    JkRS485BmsNumber *cell_smart_sleep_voltage_number_{nullptr};
+    JkRS485BmsNumber *cell_undervoltage_protection_number_{nullptr};
+    JkRS485BmsNumber *cell_undervoltage_protection_recovery_number_{nullptr};
+    JkRS485BmsNumber *cell_overvoltage_protection_number_{nullptr};
+    JkRS485BmsNumber *cell_overvoltage_protection_recovery_number_{nullptr};
+    JkRS485BmsNumber *cell_balancing_trigger_voltage_number_{nullptr};
+    JkRS485BmsNumber *cell_soc100_voltage_number_{nullptr};
+    JkRS485BmsNumber *cell_soc0_voltage_number_{nullptr};
+    JkRS485BmsNumber *cell_request_charge_voltage_number_{nullptr};
+    JkRS485BmsNumber *cell_request_float_voltage_number_{nullptr};
+    JkRS485BmsNumber *cell_power_off_voltage_number_{nullptr};
+    JkRS485BmsNumber *cell_balancing_starting_voltage_number_{nullptr};
+    JkRS485BmsNumber *max_charging_current_number_{nullptr};
+    JkRS485BmsNumber *charging_overcurrent_protection_delay_number_{nullptr};
+    JkRS485BmsNumber *charging_overcurrent_protection_recovery_delay_number_{nullptr};
+    JkRS485BmsNumber *max_discharging_current_number_{nullptr};
+    JkRS485BmsNumber *discharging_overcurrent_protection_delay_number_{nullptr};
+    JkRS485BmsNumber *discharging_overcurrent_protection_recovery_delay_number_{nullptr};
+    JkRS485BmsNumber *short_circuit_protection_delay_number_{nullptr};
+    JkRS485BmsNumber *short_circuit_protection_recovery_delay_number_{nullptr};
+    JkRS485BmsNumber *max_balancing_current_number_{nullptr};
 
-    JkRS485BmsNumber *charging_overtemperature_protection_number_; 
-    JkRS485BmsNumber *charging_overtemperature_protection_recovery_number_; 
-    JkRS485BmsNumber *discharging_overtemperature_protection_number_; 
-    JkRS485BmsNumber *discharging_overtemperature_protection_recovery_number_; 
-    JkRS485BmsNumber *charging_lowtemperature_protection_number_; 
-    JkRS485BmsNumber *charging_lowtemperature_protection_recovery_number_; 
-    JkRS485BmsNumber *mos_overtemperature_protection_number_; 
-    JkRS485BmsNumber *mos_overtemperature_protection_recovery_number_;
+    JkRS485BmsNumber *charging_overtemperature_protection_number_{nullptr};
+    JkRS485BmsNumber *charging_overtemperature_protection_recovery_number_{nullptr};
+    JkRS485BmsNumber *discharging_overtemperature_protection_number_{nullptr};
+    JkRS485BmsNumber *discharging_overtemperature_protection_recovery_number_{nullptr};
+    JkRS485BmsNumber *charging_lowtemperature_protection_number_{nullptr};
+    JkRS485BmsNumber *charging_lowtemperature_protection_recovery_number_{nullptr};
+    JkRS485BmsNumber *mos_overtemperature_protection_number_{nullptr};
+    JkRS485BmsNumber *mos_overtemperature_protection_recovery_number_{nullptr};
 
-    JkRS485BmsNumber *cell_count_settings_number_;
-    JkRS485BmsNumber *battery_capacity_total_settings_number_;
-    JkRS485BmsNumber *precharging_time_from_discharge_number_;
+    JkRS485BmsNumber *cell_count_settings_number_{nullptr};
+    JkRS485BmsNumber *battery_capacity_total_settings_number_{nullptr};
+    JkRS485BmsNumber *precharging_time_from_discharge_number_{nullptr};
 
-    JkRS485BmsNumber *cell_request_charge_voltage_time_number_;
-    JkRS485BmsNumber *cell_request_float_voltage_time_number_;
+    JkRS485BmsNumber *cell_request_charge_voltage_time_number_{nullptr};
+    JkRS485BmsNumber *cell_request_float_voltage_time_number_{nullptr};
 
     
 

--- a/components/jk_rs485_bms/jk_rs485_bms.h
+++ b/components/jk_rs485_bms/jk_rs485_bms.h
@@ -703,6 +703,7 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
   void publish_alarm_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);  
   bool should_publish_now_(uintptr_t key, uint32_t interval_ms, bool force_publish = false);
+  void flush_network_nodes_available_();
   void publish_device_unavailable_();
   void reset_status_online_tracker_();
   void track_status_online_();
@@ -710,6 +711,7 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
 
   bool status_notification_received_ = false;
   std::unordered_map<uintptr_t, uint32_t> last_publish_millis_;
+  bool network_nodes_available_dirty_{false};
 
   uint32_t last_cell_info_{0};
   uint32_t throttle_{0};

--- a/components/jk_rs485_bms/jk_rs485_bms.h
+++ b/components/jk_rs485_bms/jk_rs485_bms.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
+#include <unordered_map>
 
 float uint32_to_float(const uint8_t* byteArray);
 float int32_to_float(const uint8_t* byteArray);
@@ -701,12 +702,14 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
   void publish_state_(JkRS485BmsNumber *number, float value);  
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
   void publish_alarm_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);  
+  bool should_publish_now_(uintptr_t key, uint32_t interval_ms, bool force_publish = false);
   void publish_device_unavailable_();
   void reset_status_online_tracker_();
   void track_status_online_();
 
 
   bool status_notification_received_ = false;
+  std::unordered_map<uintptr_t, uint32_t> last_publish_millis_;
 
   uint32_t last_cell_info_{0};
   uint32_t throttle_{0};

--- a/components/jk_rs485_bms/jk_rs485_bms.h
+++ b/components/jk_rs485_bms/jk_rs485_bms.h
@@ -668,9 +668,9 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
   jk_rs485_sniffer::JkRS485Sniffer *parent_{nullptr};
   ProtocolVersion protocol_version_{PROTOCOL_VERSION_JK02_32S};
 
-  uint8_t address_;
-  uint8_t battery_total_alarms_count_;
-  uint8_t battery_total_alarms_active_;
+  uint8_t address_{0};
+  uint8_t battery_total_alarms_count_{0};
+  uint8_t battery_total_alarms_active_{0};
   std::string nodes_available;
   //std::vector<JkRS485BmsSwitch *> switches_; 
 
@@ -709,7 +709,7 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
   bool status_notification_received_ = false;
 
   uint32_t last_cell_info_{0};
-  uint32_t throttle_;
+  uint32_t throttle_{0};
 
   void decode_jk02_cell_info_(const std::vector<uint8_t> &data);
   void decode_jk02_settings_(const std::vector<uint8_t> &data);

--- a/components/jk_rs485_bms/jk_rs485_bms.h
+++ b/components/jk_rs485_bms/jk_rs485_bms.h
@@ -703,7 +703,6 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
   void publish_alarm_state_(binary_sensor::BinarySensor *binary_sensor, const bool &state);  
   bool should_publish_now_(uintptr_t key, uint32_t interval_ms, bool force_publish = false);
-  void flush_network_nodes_available_();
   void publish_device_unavailable_();
   void reset_status_online_tracker_();
   void track_status_online_();
@@ -711,7 +710,6 @@ class JkRS485Bms : public PollingComponent, public jk_rs485_sniffer::JkRS485Snif
 
   bool status_notification_received_ = false;
   std::unordered_map<uintptr_t, uint32_t> last_publish_millis_;
-  bool network_nodes_available_dirty_{false};
 
   uint32_t last_cell_info_{0};
   uint32_t throttle_{0};

--- a/components/jk_rs485_bms/number/jk_number.h
+++ b/components/jk_rs485_bms/number/jk_number.h
@@ -32,12 +32,12 @@ class JkRS485BmsNumber : public number::Number, public Component {
  protected:
   void control(float value) override;
 
-  JkRS485Bms *parent_;
-  uint16_t register_address_;
-  uint8_t third_element_of_frame_;
-  uint8_t data_length_;
+  JkRS485Bms *parent_{nullptr};
+  uint16_t register_address_{0};
+  uint8_t third_element_of_frame_{0};
+  uint8_t data_length_{0};
   float factor_{1000.0f};
-  uint8_t type_;
+  uint8_t type_{0};
 
 
 };

--- a/components/jk_rs485_bms/switch/jk_switch.cpp
+++ b/components/jk_rs485_bms/switch/jk_switch.cpp
@@ -20,8 +20,12 @@ JkRS485BmsSwitch::JkRS485BmsSwitch(bool initial_state) {
 void JkRS485BmsSwitch::dump_config() { LOG_SWITCH("", "JkRS485BmsSwitch DUMP CONFIG", this); }
 
 void JkRS485BmsSwitch::write_state(bool state) {
+    ESP_LOGVV(TAG, "JkRS485BmsSwitch::write_state() #state:%d #register:0x%04X #data_length:%d-->",
+              static_cast<int>(state), this->register_address_, this->data_length_);
+
     if (this->parent_ == nullptr) {
         ESP_LOGE(TAG, "Parent is null");
+        ESP_LOGVV(TAG, "JkRS485BmsSwitch::write_state()--<");
         return;
     }
 
@@ -35,9 +39,8 @@ void JkRS485BmsSwitch::write_state(bool state) {
       }
       //this->publish_state(state);
     }
-    
 
-    
+    ESP_LOGVV(TAG, "JkRS485BmsSwitch::write_state()--<");
 }
 
 

--- a/components/jk_rs485_bms/switch/jk_switch.h
+++ b/components/jk_rs485_bms/switch/jk_switch.h
@@ -38,10 +38,10 @@ class JkRS485BmsSwitch : public switch_::Switch, public Component {
   
  protected:
 
-  JkRS485Bms *parent_;
-  uint16_t register_address_;
-  uint8_t third_element_of_frame_;
-  uint8_t data_length_;
+  JkRS485Bms *parent_{nullptr};
+  uint16_t register_address_{0};
+  uint8_t third_element_of_frame_{0};
+  uint8_t data_length_{0};
 };
 
 

--- a/components/jk_rs485_sniffer/__init__.py
+++ b/components/jk_rs485_sniffer/__init__.py
@@ -12,6 +12,9 @@ CONF_RX_TIMEOUT = "rx_timeout"
 CONF_PROTOCOL_VERSION = "protocol_version"
 CONF_TALK_PIN = "talk_pin"
 CONF_MASTER_FW_VERSION = "master_fw_version"
+CONF_SENSOR_PUBLISH_INTERVAL = "sensor_publish_interval"
+CONF_NUMBER_PUBLISH_INTERVAL = "number_publish_interval"
+CONF_TEXT_PUBLISH_INTERVAL = "text_publish_interval"
 
 jk_rs485_sniffer_ns = cg.esphome_ns.namespace("jk_rs485_sniffer")
 
@@ -43,7 +46,16 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_TALK_PIN): pins.internal_gpio_output_pin_schema,
             cv.Optional(
                 CONF_RX_TIMEOUT, default="50ms"
-            ): cv.positive_time_period_milliseconds,            
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_SENSOR_PUBLISH_INTERVAL, default="10s"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_NUMBER_PUBLISH_INTERVAL, default="10s"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_TEXT_PUBLISH_INTERVAL, default="10s"
+            ): cv.positive_time_period_milliseconds,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -64,6 +76,9 @@ async def to_code(config):
 
     await uart.register_uart_device(var, config)
     cg.add(var.set_rx_timeout(config[CONF_RX_TIMEOUT]))
+    cg.add(var.set_sensor_publish_interval(config[CONF_SENSOR_PUBLISH_INTERVAL]))
+    cg.add(var.set_number_publish_interval(config[CONF_NUMBER_PUBLISH_INTERVAL]))
+    cg.add(var.set_text_publish_interval(config[CONF_TEXT_PUBLISH_INTERVAL]))
 
     if CONF_TALK_PIN in config:
        talk_pin = await cg.gpio_pin_expression(config[CONF_TALK_PIN])

--- a/components/jk_rs485_sniffer/jk_rs485_sniffer.cpp
+++ b/components/jk_rs485_sniffer/jk_rs485_sniffer.cpp
@@ -1110,7 +1110,6 @@ void JkRS485Sniffer::detected_master_activity_now(void) {
 }
 
 uint8_t JkRS485Sniffer::manage_rx_buffer_(void) {
-  const uint8_t *raw = &this->rx_buffer_[0];
   uint8_t address = 0;
   
   const uint32_t now = millis();
@@ -1120,7 +1119,13 @@ uint8_t JkRS485Sniffer::manage_rx_buffer_(void) {
 
   ESP_LOGV(TAG, "JkRS485Sniffer::manage_rx_buffer_()-[buffer: %d bytes]",this->rx_buffer_.size());
 
+  if (this->rx_buffer_.empty()) {
+    ESP_LOGVV(TAG, "JkRS485Sniffer::manage_rx_buffer_()-Return 5 (empty buffer)");
+    return(5);
+  }
+
   if (this->rx_buffer_.size() >= JKPB_RS485_MASTER_SHORT_REQUEST_SIZE) {
+    const uint8_t *raw = this->rx_buffer_.data();
     auto it = std::search(this->rx_buffer_.begin(), this->rx_buffer_.end(), pattern_response_header.begin(), pattern_response_header.end());
     
     if (it == this->rx_buffer_.end()) {
@@ -1162,6 +1167,7 @@ uint8_t JkRS485Sniffer::manage_rx_buffer_(void) {
   }
 
   if (this->rx_buffer_.size() >= JKPB_RS485_MASTER_REQUEST_SIZE) {
+    const uint8_t *raw = this->rx_buffer_.data();
     auto it = std::search(this->rx_buffer_.begin(), this->rx_buffer_.end(), pattern_response_header.begin(), pattern_response_header.end());
     bool try_with_master_request_size = false;
 
@@ -1277,6 +1283,7 @@ uint8_t JkRS485Sniffer::manage_rx_buffer_(void) {
     // ESP_LOGVV(TAG, "JkRS485Sniffer::manage_rx_buffer_()- before JKPB_RS485_RESPONSE_SIZE 2 - address [0x%02X]", address);        
 
   if (this->rx_buffer_.size() >= JKPB_RS485_RESPONSE_SIZE) {
+    const uint8_t *raw = this->rx_buffer_.data();
     ESP_LOGVV(TAG, "JkRS485Sniffer::manage_rx_buffer_()-this->rx_buffer_.size() >= JKPB_RS485_RESPONSE_SIZE 2");
 
     uint8_t computed_checksum = chksum(raw, JKPB_RS485_NUMBER_OF_ELEMENTS_TO_COMPUTE_CHECKSUM);

--- a/components/jk_rs485_sniffer/jk_rs485_sniffer.cpp
+++ b/components/jk_rs485_sniffer/jk_rs485_sniffer.cpp
@@ -642,9 +642,7 @@ void JkRS485Sniffer::loop_old() {
     // ESP_LOGD(TAG, "original_buffer_size < JKPB_RS485_MASTER_SHORT_REQUEST_SIZE");
     // ESP_LOGD(TAG, "..........................................");
 
-      if (ESP_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
-        printBuffer_segmented(this->rx_buffer_, 0);
-      }
+      // Disabled in hot path to avoid blocking the component loop.
       
       response = this->manage_rx_buffer_();
       ESP_LOGVV(TAG, "manage_rx_buffer_()-Response: %d:", response);
@@ -790,9 +788,7 @@ void JkRS485Sniffer::loop() {
 
     
     ESP_LOGV(TAG, "JkRS485Sniffer::loop()-Buffer fill:");
-    if (ESP_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
-      printBuffer_segmented(this->rx_buffer_.size());
-    }
+    // Disabled in hot path to avoid blocking the component loop.
   
     response = this->manage_rx_buffer_();
 
@@ -1355,9 +1351,7 @@ uint8_t JkRS485Sniffer::manage_rx_buffer_(void) {
     // std::vector<uint8_t> data(this->rx_buffer_.begin() + 0, this->rx_buffer_.begin() + this->rx_buffer_.size() + 1);
     std::vector<uint8_t> data(this->rx_buffer_.begin() + 0, this->rx_buffer_.begin() + JKPB_RS485_RESPONSE_SIZE);
 
-    if (ESP_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
-      printBuffer_segmented(data, 0);
-    }
+    // Disabled in hot path to avoid blocking the component loop.
 
     ESP_LOGI(TAG, "Frame received from address: %02X type of information: 0x%02X)  ", address, raw[4]);
     ESP_LOGD(TAG, "Frame received from SLAVE (type: 0x%02X, %d bytes) %02X address", raw[4], data.size(), address);
@@ -1366,9 +1360,7 @@ uint8_t JkRS485Sniffer::manage_rx_buffer_(void) {
 
     ESP_LOGD(TAG, "JkRS485Sniffer::manage_rx_buffer_()-JKPB_RS485_RESPONSE_SIZE 2: Frame received from SLAVE (type: 0x%02X, %d bytes) %02X address", raw[4], data.size(), address);
     // ESP_LOGVV(TAG, "[%s]", format_hex_pretty(&data.front(), data.size()).c_str());
-    if (ESP_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
-      printBuffer_segmented(this->rx_buffer_.size());
-    }
+    // Disabled in hot path to avoid blocking the component loop.
 
     bool found = false;
 

--- a/components/jk_rs485_sniffer/jk_rs485_sniffer.cpp
+++ b/components/jk_rs485_sniffer/jk_rs485_sniffer.cpp
@@ -156,7 +156,7 @@ void JkRS485Sniffer::handle_bms2sniffer_switch_or_number_uint32_event(std::uint8
   if (this->broadcast_changes_to_all_bms_ == true) {
     for (uint8_t j = 1; j < 16; ++j) {
       if (rs485_network_node[j].available && slave_address != j) {
-        delayMicroseconds(50000);
+        delayMicroseconds(5000);
         send_command_switch_or_number_to_slave_uint32(j, third_element_of_frame, register_address, value);
       }
     }
@@ -185,7 +185,7 @@ void JkRS485Sniffer::handle_bms2sniffer_switch_or_number_int32_event(std::uint8_
   if (this->broadcast_changes_to_all_bms_ == true) {
     for (uint8_t j = 1; j < 16; ++j) {
       if (rs485_network_node[j].available && slave_address != j) {
-        delayMicroseconds(50000);
+        delayMicroseconds(5000);
         send_command_switch_or_number_to_slave_int32(j, third_element_of_frame, register_address, value);
       }
     }
@@ -210,7 +210,7 @@ void JkRS485Sniffer::handle_bms2sniffer_switch_or_number_uint16_event(std::uint8
   if (this->broadcast_changes_to_all_bms_ == true) {
     for (uint8_t j = 1; j < 16; ++j) {
       if (rs485_network_node[j].available && slave_address != j) {
-        delayMicroseconds(50000);
+        delayMicroseconds(5000);
         send_command_switch_or_number_to_slave_uint16(j, third_element_of_frame, register_address, value);
         rs485_network_node[j].last_device_info_request_received_OK = 0;
       }
@@ -642,7 +642,9 @@ void JkRS485Sniffer::loop_old() {
     // ESP_LOGD(TAG, "original_buffer_size < JKPB_RS485_MASTER_SHORT_REQUEST_SIZE");
     // ESP_LOGD(TAG, "..........................................");
 
-      printBuffer_segmented(this->rx_buffer_, 0);         
+      if (ESP_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
+        printBuffer_segmented(this->rx_buffer_, 0);
+      }
       
       response = this->manage_rx_buffer_();
       ESP_LOGVV(TAG, "manage_rx_buffer_()-Response: %d:", response);
@@ -788,7 +790,9 @@ void JkRS485Sniffer::loop() {
 
     
     ESP_LOGV(TAG, "JkRS485Sniffer::loop()-Buffer fill:");
-    printBuffer_segmented(this->rx_buffer_.size());
+    if (ESP_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
+      printBuffer_segmented(this->rx_buffer_.size());
+    }
   
     response = this->manage_rx_buffer_();
 
@@ -1351,7 +1355,9 @@ uint8_t JkRS485Sniffer::manage_rx_buffer_(void) {
     // std::vector<uint8_t> data(this->rx_buffer_.begin() + 0, this->rx_buffer_.begin() + this->rx_buffer_.size() + 1);
     std::vector<uint8_t> data(this->rx_buffer_.begin() + 0, this->rx_buffer_.begin() + JKPB_RS485_RESPONSE_SIZE);
 
-    printBuffer_segmented(data, 0);
+    if (ESP_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
+      printBuffer_segmented(data, 0);
+    }
 
     ESP_LOGI(TAG, "Frame received from address: %02X type of information: 0x%02X)  ", address, raw[4]);
     ESP_LOGD(TAG, "Frame received from SLAVE (type: 0x%02X, %d bytes) %02X address", raw[4], data.size(), address);
@@ -1360,7 +1366,9 @@ uint8_t JkRS485Sniffer::manage_rx_buffer_(void) {
 
     ESP_LOGD(TAG, "JkRS485Sniffer::manage_rx_buffer_()-JKPB_RS485_RESPONSE_SIZE 2: Frame received from SLAVE (type: 0x%02X, %d bytes) %02X address", raw[4], data.size(), address);
     // ESP_LOGVV(TAG, "[%s]", format_hex_pretty(&data.front(), data.size()).c_str());
-    printBuffer_segmented(this->rx_buffer_.size());      
+    if (ESP_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
+      printBuffer_segmented(this->rx_buffer_.size());
+    }
 
     bool found = false;
 

--- a/components/jk_rs485_sniffer/jk_rs485_sniffer.h
+++ b/components/jk_rs485_sniffer/jk_rs485_sniffer.h
@@ -146,7 +146,17 @@ class JkRS485Sniffer : public uart::UARTDevice, public output::TalkPin, public C
   uint32_t last_jk_rs485_pooling_trial_{0};
   std::vector<JkRS485SnifferDevice *> devices_;  
 
-  void write_state(bool state) override { this->talk_pin_->digital_write(state); }
+  void write_state(bool state) override {
+    ESP_LOGVV("jk_rs485_sniffer", "JkRS485Sniffer::write_state() #state:%d-->",
+              static_cast<int>(state));
+    if (this->talk_pin_ == nullptr) {
+      ESP_LOGE("jk_rs485_sniffer", "JkRS485Sniffer::write_state() #error:talk_pin_null");
+      ESP_LOGVV("jk_rs485_sniffer", "JkRS485Sniffer::write_state()--<");
+      return;
+    }
+    this->talk_pin_->digital_write(state);
+    ESP_LOGVV("jk_rs485_sniffer", "JkRS485Sniffer::write_state()--<");
+  }
   //void write_state(bool state) override { this->set_state(state); }
   GPIOPin *talk_pin_;
   bool talk_pin_needed_;

--- a/components/jk_rs485_sniffer/jk_rs485_sniffer.h
+++ b/components/jk_rs485_sniffer/jk_rs485_sniffer.h
@@ -103,6 +103,12 @@ class JkRS485Sniffer : public uart::UARTDevice, public output::TalkPin, public C
   float get_setup_priority() const override;
 
   void set_rx_timeout(uint16_t rx_timeout) { rx_timeout_ = rx_timeout; }
+  void set_sensor_publish_interval(uint32_t interval_ms) { sensor_publish_interval_ms_ = interval_ms; }
+  void set_number_publish_interval(uint32_t interval_ms) { number_publish_interval_ms_ = interval_ms; }
+  void set_text_publish_interval(uint32_t interval_ms) { text_publish_interval_ms_ = interval_ms; }
+  uint32_t get_sensor_publish_interval() const { return sensor_publish_interval_ms_; }
+  uint32_t get_number_publish_interval() const { return number_publish_interval_ms_; }
+  uint32_t get_text_publish_interval() const { return text_publish_interval_ms_; }
 
   void handle_bms2sniffer_event(std::uint8_t slave_address, std::string event, std::uint8_t frame_type);
 
@@ -141,6 +147,9 @@ class JkRS485Sniffer : public uart::UARTDevice, public output::TalkPin, public C
 
   std::vector<uint8_t> rx_buffer_;
   uint16_t rx_timeout_{50};
+  uint32_t sensor_publish_interval_ms_{10000};
+  uint32_t number_publish_interval_ms_{10000};
+  uint32_t text_publish_interval_ms_{10000};
   bool broadcast_changes_to_all_bms_;
   uint32_t last_jk_rs485_network_activity_{0};
   uint32_t last_jk_rs485_pooling_trial_{0};

--- a/esphome-jk-bms.code-workspace
+++ b/esphome-jk-bms.code-workspace
@@ -1,11 +1,17 @@
 {
   "folders": [
     {
-      "path": "."
+      "path": ".",
     },
     {
-      "path": "../esphome-jk-bms-documentation"
-    }
+      "path": "../esphome-jk-bms-documentation",
+    },
+    {
+      "path": "../../PowerShell/PowerShell.FramesJKBMS",
+    },
+    {
+      "path": "../../PowerShell/PowerShell.Global",
+    },
   ],
   "settings": {
     "files.associations": {
@@ -66,7 +72,7 @@
       "streambuf": "cpp",
       "thread": "cpp",
       "typeinfo": "cpp",
-      "xutility": "cpp"
-    }
-  }
+      "xutility": "cpp",
+    },
+  },
 }


### PR DESCRIPTION
## Summary

This PR merges `development_20260401` into `main` for the `v1.6` release.

## Main changes

- Added configurable publish intervals in `jk_rs485_sniffer` for sensors, numbers, and text sensors.
- Reduced Home Assistant/API load by throttling non-binary publications.
- Kept alarms and binary sensors immediate while delaying heavier state updates.
- Fixed `network_nodes_available` publication so the latest value is preserved while throttling is active.
- Improved stability around API disconnects, reconnections, and high publish rates.
- Hardened frame decoding and parser safety for short frames, invalid cell counts, null optional entities, and RX buffer handling.
- Allowed RS485 address `0x00` in `jk_rs485_bms` validation.
- Updated in-repo documentation and changelog.

## Context

The branch contains the work that stabilized the RS485 sniffer hot path and reduced Home Assistant communication issues seen in recent testing.

## Validation

- Reviewed changelog alignment
- Reviewed diff against `main`
- Release target: `v1.6`